### PR TITLE
migrate rust-gpu v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,12 +165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bimap"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
-
-[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,9 +649,19 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "elsa"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e0aca8dce8856e420195bd13b6a64de3334235ccc9214e824b86b12bf26283"
+dependencies = [
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "emath"
@@ -1055,6 +1059,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "internal-iterator"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668ef46056a63366da9d74f48062da9ece1a27958f2f3704aa6f7421c4433f5"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1178,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "longest-increasing-subsequence"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 
 [[package]]
 name = "malloc_buf"
@@ -1920,14 +1945,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_codegen_spirv"
-version = "0.4.0-alpha.16"
-source = "git+https://github.com/EmbarkStudios/rust-gpu/?rev=c248806bf0be9cc59e996e0cf61585513a0e3890#c248806bf0be9cc59e996e0cf61585513a0e3890"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48862935255ac76002118e3561c54f3fb413a752ef5cd0bdae693cf5c5ce37a5"
 dependencies = [
  "ar",
- "bimap",
+ "either",
  "hashbrown 0.11.2",
  "indexmap",
+ "itertools",
+ "lazy_static",
  "libc",
  "num-traits",
  "once_cell",
@@ -1939,14 +1973,16 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "spirt",
  "spirv-tools",
  "syn",
 ]
 
 [[package]]
 name = "rustc_codegen_spirv-types"
-version = "0.4.0-alpha.16"
-source = "git+https://github.com/EmbarkStudios/rust-gpu/?rev=c248806bf0be9cc59e996e0cf61585513a0e3890#c248806bf0be9cc59e996e0cf61585513a0e3890"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339309d7fce2e7204decea1b2683c4d439a6ebe4c1518d8134fe10aefeae7362"
 dependencies = [
  "rspirv",
  "serde",
@@ -2145,6 +2181,9 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2195,6 +2234,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spirt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24fa996f12f3c667efbceaa99c222b8910a295a14d2c43c3880dfab2752def7"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bytemuck",
+ "elsa",
+ "indexmap",
+ "internal-iterator",
+ "itertools",
+ "lazy_static",
+ "longest-increasing-subsequence",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
 name = "spirv"
 version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,8 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-builder"
-version = "0.4.0-alpha.16"
-source = "git+https://github.com/EmbarkStudios/rust-gpu/?rev=c248806bf0be9cc59e996e0cf61585513a0e3890#c248806bf0be9cc59e996e0cf61585513a0e3890"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0310607328cbb098b681e4580a25871fcf72dd9e1d560e7cc09c409eedef2a27"
 dependencies = [
  "memchr",
  "raw-string",
@@ -2219,8 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-std"
-version = "0.4.0-alpha.16"
-source = "git+https://github.com/EmbarkStudios/rust-gpu/?rev=c248806bf0be9cc59e996e0cf61585513a0e3890#c248806bf0be9cc59e996e0cf61585513a0e3890"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3197bd4c021c2dfc0f9dfb356312c8f7842d972d5545c308ad86422c2e2d3e66"
 dependencies = [
  "bitflags",
  "glam",
@@ -2231,8 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-macros"
-version = "0.4.0-alpha.16"
-source = "git+https://github.com/EmbarkStudios/rust-gpu/?rev=c248806bf0be9cc59e996e0cf61585513a0e3890#c248806bf0be9cc59e996e0cf61585513a0e3890"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaffad626ab9d3ac61c4b74b5d51cb52f1939a8041d7ac09ec828eb4ad44d72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2242,8 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-std-types"
-version = "0.4.0-alpha.16"
-source = "git+https://github.com/EmbarkStudios/rust-gpu/?rev=c248806bf0be9cc59e996e0cf61585513a0e3890#c248806bf0be9cc59e996e0cf61585513a0e3890"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab83875e851bc803c687024d2d950730f350c0073714b95b3a6b1d22e9eac42a"
 
 [[package]]
 name = "spirv-tools"
@@ -2262,6 +2325,12 @@ checksum = "b4b32d9d6469cd6b50dcd6bd841204b5946b4fb7b70a97872717cdc417659c9a"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "str-buf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ once_cell = "1.13.1"
 qcell = "0.5.2"
 regex = "1.6.0"
 shader_builder = { path = "mpdelta_build_utils/shader_builder" }
-spirv-builder = { git = "https://github.com/EmbarkStudios/rust-gpu/", rev = "c248806bf0be9cc59e996e0cf61585513a0e3890" }
-spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu/", rev = "c248806bf0be9cc59e996e0cf61585513a0e3890", features = ["glam"] }
+spirv-builder = "0.7.0"
+spirv-std = "0.7.0"
 thiserror = "1.0.31"
 time = { version = "0.3.11", features = ["std"] }
 tokio = { version = "1.19.2", features = ["full"] }

--- a/mpdelta_build_utils/rust_gpu_builder/rust-toolchain
+++ b/mpdelta_build_utils/rust_gpu_builder/rust-toolchain
@@ -5,9 +5,7 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "nightly-2022-10-01"
+channel = "nightly-2023-03-04"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
-# commit_hash = 8ce3204af9463db3192ea1eb31c45c2f6d4b5ae6
 
-# Whenever changing the nightly channel, update the commit hash above, and make
-# sure to change REQUIRED_TOOLCHAIN in crates/rustc_codegen_spirv/src/build.rs also.
+# required toolchain is defined in https://github.com/EmbarkStudios/rust-gpu/blob/v0.7.0/crates/rustc_codegen_spirv/build.rs

--- a/mpdelta_video_renderer_vulkano/shaders/composite_operation/src/lib.rs
+++ b/mpdelta_video_renderer_vulkano/shaders/composite_operation/src/lib.rs
@@ -17,23 +17,23 @@ pub struct CompositeOperationConstant {
 #[cfg(feature = "shader")]
 pub mod shader {
     use crate::CompositeOperationConstant;
-    use spirv_std::glam::{UVec3, UVec4, Vec3Swizzles, Vec4, Vec4Swizzles};
+    use spirv_std::glam::{UVec3, Vec3Swizzles, Vec4, Vec4Swizzles};
     use spirv_std::spirv;
     use spirv_std::Image;
 
     #[spirv(compute(threads(32, 32, 1)))]
     pub fn main(
         #[spirv(global_invocation_id)] id: UVec3,
-        #[spirv(descriptor_set = 0, binding = 0)] result_image: &mut Image!(2D, format=rgba8, sampled=false, arrayed=false),
-        #[spirv(descriptor_set = 1, binding = 0)] image: &Image!(2D, format=rgba8, sampled=false, arrayed=false),
-        #[spirv(descriptor_set = 1, binding = 1)] stencil: &Image!(2D, format=r32ui, sampled=false, arrayed=false),
+        #[spirv(descriptor_set = 0, binding = 0)] result_image: &Image!(2D, format = rgba8, sampled = false, arrayed = false),
+        #[spirv(descriptor_set = 1, binding = 0)] image: &Image!(2D, format = rgba8, sampled = false, arrayed = false),
+        #[spirv(descriptor_set = 1, binding = 1)] stencil: &Image!(2D, format = r32ui, sampled = false, arrayed = false),
         #[spirv(push_constant)] constant: &CompositeOperationConstant,
     ) {
         if constant.image_width <= id.x || constant.image_height <= id.y {
             return;
         }
-        let stencil: UVec4 = stencil.read(id.xy());
-        if stencil.x == 0 {
+        let stencil: u32 = stencil.read(id.xy());
+        if stencil == 0 {
             return;
         }
         let dest_color: Vec4 = result_image.read(id.xy());


### PR DESCRIPTION
Closes: #16

今までコミットハッシュ指定で参照していたspirv-builderとspirv-stdをcrates.ioから参照するようにした