### PR TITLE
GUIのホットリロードをするためのcrateを作る

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,13 @@
 !/Cargo.toml
 !/rustfmt.toml
 !/mpdelta_build_utils
+!/mpdelta_common
 !/mpdelta_components
 !/mpdelta_core
+!/mpdelta_dyn_usecase
 !/mpdelta_core_vulkano
 !/mpdelta_gui
+!/mpdelta_gui_hot_reload
 !/mpdelta_gui_vulkano
 !/mpdelta_services
 !/mpdelta_renderer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "getrandom",
  "once_cell",
  "version_check",
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64529721f27c2314ced0890ce45e469574a73e5e6fdd6e9da1860eb29285f5e0"
 dependencies = [
  "android-properties",
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "jni-sys",
  "libc",
@@ -117,7 +117,7 @@ dependencies = [
  "objc_id",
  "parking_lot",
  "thiserror",
- "winapi",
+ "winapi 0.3.9",
  "x11rb",
 ]
 
@@ -179,7 +179,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -196,7 +196,7 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -214,6 +214,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block"
@@ -284,7 +290,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e0d00eb1ea24371a97d2da6201c6747a633dc6dc1988ef503403b4c59504a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "log",
  "nix 0.25.1",
  "slotmap",
@@ -307,6 +313,12 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -337,7 +349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "indexmap 1.9.3",
@@ -377,7 +389,7 @@ checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
 dependencies = [
  "error-code",
  "str-buf",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -433,7 +445,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -446,7 +458,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "libc",
 ]
@@ -457,7 +469,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -466,7 +478,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -476,7 +488,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -488,7 +500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset 0.9.0",
  "scopeguard",
@@ -500,7 +512,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -510,7 +522,7 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -525,7 +537,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
@@ -709,6 +721,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +778,50 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags 1.3.2",
+ "fsevent-sys 2.0.1",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -873,7 +941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -882,7 +950,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi",
@@ -921,7 +989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crunchy",
 ]
 
@@ -977,6 +1045,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hot-lib-reloader"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7767568f2f3adb7ce2926a261fd838f161f3549c1b7e64a4c67a8a4c574e8c"
+dependencies = [
+ "crc32fast",
+ "hot-lib-reloader-macro",
+ "libloading 0.7.4",
+ "log",
+ "notify 4.0.17",
+ "thiserror",
+]
+
+[[package]]
+name = "hot-lib-reloader-macro"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5551f8a39fa95a6b6d0cc0a8a7ccf8df4d62cc12731d5153eb64e1405e77762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,12 +1119,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1042,6 +1166,15 @@ name = "internal-iterator"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a668ef46056a63366da9d74f48062da9ece1a27958f2f3704aa6f7421c4433f5"
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "itertools"
@@ -1065,7 +1198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.0",
  "combine",
  "jni-sys",
  "log",
@@ -1108,10 +1241,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lebe"
@@ -1131,8 +1300,8 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if",
- "winapi",
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1141,7 +1310,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
 
@@ -1179,7 +1348,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "generator",
  "scoped-tls",
  "tracing",
@@ -1255,6 +1424,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
@@ -1266,10 +1454,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
 name = "mpdelta"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "mpdelta_async_runtime",
  "mpdelta_components",
  "mpdelta_core",
  "mpdelta_core_vulkano",
@@ -1284,6 +1497,14 @@ dependencies = [
  "vulkano-util",
  "vulkano-win",
  "winit",
+]
+
+[[package]]
+name = "mpdelta_async_runtime"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "tokio",
 ]
 
 [[package]]
@@ -1321,19 +1542,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpdelta_dyn_usecase"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "mpdelta_core",
+ "qcell",
+ "tokio",
+]
+
+[[package]]
 name = "mpdelta_gui"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
- "bitflags",
+ "bitflags 1.3.2",
  "cgmath",
  "dashmap",
  "egui",
  "futures",
+ "mpdelta_async_runtime",
  "mpdelta_core",
  "once_cell",
  "qcell",
  "regex",
+ "tokio",
+]
+
+[[package]]
+name = "mpdelta_gui_hot_reload"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "egui",
+ "hot-lib-reloader",
+ "mpdelta_async_runtime",
+ "mpdelta_components",
+ "mpdelta_core",
+ "mpdelta_core_vulkano",
+ "mpdelta_dyn_usecase",
+ "mpdelta_gui",
+ "mpdelta_gui_hot_reload_lib",
+ "mpdelta_gui_vulkano",
+ "mpdelta_renderer",
+ "mpdelta_services",
+ "mpdelta_video_renderer_vulkano",
+ "notify 6.1.1",
+ "qcell",
+ "tokio",
+ "vulkano",
+ "vulkano-util",
+ "vulkano-win",
+ "winit",
+]
+
+[[package]]
+name = "mpdelta_gui_hot_reload_lib"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "egui",
+ "mpdelta_async_runtime",
+ "mpdelta_core",
+ "mpdelta_core_vulkano",
+ "mpdelta_dyn_usecase",
+ "mpdelta_gui",
+ "mpdelta_renderer",
+ "qcell",
  "tokio",
 ]
 
@@ -1419,7 +1695,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum 0.5.11",
@@ -1443,13 +1719,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
- "cfg-if",
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -1461,8 +1748,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
- "cfg-if",
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -1484,13 +1771,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+dependencies = [
+ "bitflags 1.3.2",
+ "filetime",
+ "fsevent",
+ "fsevent-sys 2.0.1",
+ "inotify 0.7.1",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys 4.1.0",
+ "inotify 0.9.6",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.8",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1692,7 +2016,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1749,7 +2073,7 @@ version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1903,7 +2227,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2232,7 +2556,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "calloop",
  "dlib",
  "lazy_static",
@@ -2301,7 +2625,7 @@ version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "num-traits",
 ]
 
@@ -2325,7 +2649,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c3c0972a2df79abe2c8af2fe7f7937a9aa558b6a1f78fc5edf93f4d480d757"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "glam",
  "num-traits",
  "spirv-std-macros",
@@ -2455,7 +2779,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -2496,7 +2820,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.0",
  "png",
  "tiny-skia-path",
 ]
@@ -2536,7 +2860,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 0.8.8",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
@@ -2580,7 +2904,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2815,7 +3139,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -2869,7 +3193,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "libc",
  "nix 0.24.3",
@@ -2908,7 +3232,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "wayland-client",
  "wayland-commons",
  "wayland-scanner",
@@ -2971,6 +3295,12 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2978,6 +3308,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2991,7 +3327,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3000,7 +3336,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3157,7 +3493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
 dependencies = [
  "android-activity",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg_aliases",
  "core-foundation",
  "core-graphics",
@@ -3165,7 +3501,7 @@ dependencies = [
  "instant",
  "libc",
  "log",
- "mio",
+ "mio 0.8.8",
  "ndk",
  "objc2",
  "once_cell",
@@ -3195,6 +3531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,7 +3559,7 @@ checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
 dependencies = [
  "gethostname",
  "nix 0.24.3",
- "winapi",
+ "winapi 0.3.9",
  "winapi-wsapoll",
  "x11rb-protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mpdelta"
 version = "0.1.0"
 edition = "2021"
+default-run = "mpdelta"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,10 +11,14 @@ members = [
     ".",
     "mpdelta_build_utils/rust_gpu_builder",
     "mpdelta_build_utils/shader_builder",
+    "mpdelta_common/mpdelta_async_runtime",
     "mpdelta_components",
     "mpdelta_core",
     "mpdelta_core_vulkano",
+    "mpdelta_dyn_usecase",
     "mpdelta_gui",
+    "mpdelta_gui_hot_reload",
+    "mpdelta_gui_hot_reload/mpdelta_gui_hot_reload_lib",
     "mpdelta_gui_vulkano",
     "mpdelta_services",
     "mpdelta_renderer",
@@ -24,10 +29,14 @@ members = [
 default-members = [
     ".",
     "mpdelta_build_utils/shader_builder",
+    "mpdelta_common/mpdelta_async_runtime",
     "mpdelta_components",
     "mpdelta_core",
     "mpdelta_core_vulkano",
+    "mpdelta_dyn_usecase",
     "mpdelta_gui",
+    "mpdelta_gui_hot_reload",
+    "mpdelta_gui_hot_reload/mpdelta_gui_hot_reload_lib",
     "mpdelta_gui_vulkano",
     "mpdelta_services",
     "mpdelta_renderer",
@@ -49,14 +58,18 @@ egui_winit_vulkano = "0.24.0"
 either = "1.7.0"
 futures = "0.3.21"
 glam = { version = "0.24", default-features = false, features = ["libm"] }
+hot-lib-reloader = "0.6.5"
 mpdelta_components = { path = "mpdelta_components" }
+mpdelta_async_runtime = { path = "mpdelta_common/mpdelta_async_runtime" }
 mpdelta_core = { path = "mpdelta_core" }
 mpdelta_core_vulkano = { path = "mpdelta_core_vulkano" }
+mpdelta_dyn_usecase = { path = "mpdelta_dyn_usecase" }
 mpdelta_gui = { path = "mpdelta_gui" }
 mpdelta_gui_vulkano = { path = "mpdelta_gui_vulkano" }
 mpdelta_renderer = { path = "mpdelta_renderer" }
 mpdelta_services = { path = "mpdelta_services" }
 mpdelta_video_renderer_vulkano = { path = "mpdelta_video_renderer_vulkano" }
+notify = "6.1.1"
 once_cell = "1.13.1"
 qcell = "0.5.2"
 regex = "1.6.0"
@@ -65,7 +78,7 @@ spirv-builder = "0.9.0"
 spirv-std = "0.9.0"
 thiserror = "1.0.31"
 time = { version = "0.3.11", features = ["std"] }
-tokio = { version = "1.19.2", features = ["full"] }
+tokio = { version = "1.19.2", features = ["fs", "macros", "sync", "time"] }
 uuid = "1.0.0"
 vulkano = "0.33.0"
 vulkano-util = "0.33.0"
@@ -75,6 +88,7 @@ winit = "0.28.3"
 
 [dependencies]
 async-trait = { workspace = true }
+mpdelta_async_runtime = { workspace = true, features = ["tokio"] }
 mpdelta_components = { workspace = true }
 mpdelta_core = { workspace = true }
 mpdelta_core_vulkano = { workspace = true }

--- a/mpdelta_common/mpdelta_async_runtime/Cargo.toml
+++ b/mpdelta_common/mpdelta_async_runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mpdelta_async_runtime"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futures = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }

--- a/mpdelta_common/mpdelta_async_runtime/src/implementation.rs
+++ b/mpdelta_common/mpdelta_async_runtime/src/implementation.rs
@@ -1,0 +1,27 @@
+use crate::AnyAsyncRuntime;
+use std::future::Future;
+use tokio::runtime::Handle;
+use tokio::task::{JoinError, JoinHandle};
+
+impl AnyAsyncRuntime for Handle {
+    type Err = JoinError;
+    type JoinHandle<T: Send + 'static> = JoinHandle<T>;
+
+    fn spawn<Fut>(&self, fut: Fut) -> Self::JoinHandle<Fut::Output>
+    where
+        Fut: Future + Send + 'static,
+        Fut::Output: Send,
+    {
+        self.spawn(fut)
+    }
+}
+
+impl<T: Send> crate::JoinHandle for JoinHandle<T> {
+    fn abort(&self) {
+        JoinHandle::abort(self)
+    }
+
+    fn is_finished(&self) -> bool {
+        JoinHandle::is_finished(self)
+    }
+}

--- a/mpdelta_common/mpdelta_async_runtime/src/lib.rs
+++ b/mpdelta_common/mpdelta_async_runtime/src/lib.rs
@@ -1,0 +1,163 @@
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+#[cfg(feature = "tokio")]
+pub mod implementation;
+
+pub trait JoinHandle: Future + Send + Sync {
+    fn abort(&self);
+    fn is_finished(&self) -> bool;
+}
+
+impl<T: JoinHandle + Unpin + ?Sized> JoinHandle for Box<T> {
+    fn abort(&self) {
+        T::abort(self)
+    }
+
+    fn is_finished(&self) -> bool {
+        T::is_finished(self)
+    }
+}
+
+impl<T: JoinHandle + ?Sized> JoinHandle for Pin<Box<T>> {
+    fn abort(&self) {
+        T::abort(self)
+    }
+
+    fn is_finished(&self) -> bool {
+        T::is_finished(self)
+    }
+}
+
+pub trait AnyAsyncRuntime: Send + Sync {
+    type Err: Error + Send + 'static;
+    type JoinHandle<T: Send + 'static>: JoinHandle<Output = Result<T, Self::Err>> + 'static;
+    fn spawn<Fut>(&self, fut: Fut) -> Self::JoinHandle<Fut::Output>
+    where
+        Fut: Future + Send + 'static,
+        Fut::Output: Send;
+}
+
+pub trait AsyncRuntime<Out>: Send + Sync {
+    type Err: Error + Send + 'static;
+    type JoinHandle: JoinHandle<Output = Result<Out, Self::Err>> + 'static;
+    fn spawn<Fut: Future<Output = Out> + Send + 'static>(&self, fut: Fut) -> Self::JoinHandle;
+}
+
+pub trait AsyncRuntimeDyn<Out>: Send + Sync {
+    fn spawn_dyn(&self, fut: Pin<Box<dyn Future<Output = Out> + Send + 'static>>) -> Pin<Box<dyn JoinHandle<Output = Result<Out, BoxedError>>>>;
+}
+
+impl<Runtime: AnyAsyncRuntime, T: Send + 'static> AsyncRuntime<T> for Runtime {
+    type Err = Runtime::Err;
+    type JoinHandle = Runtime::JoinHandle<T>;
+
+    fn spawn<Fut: Future<Output = T> + Send + 'static>(&self, fut: Fut) -> Self::JoinHandle {
+        AnyAsyncRuntime::spawn(self, fut)
+    }
+}
+
+impl<Out: 'static, T> AsyncRuntimeDyn<Out> for T
+where
+    T: AsyncRuntime<Out>,
+{
+    fn spawn_dyn(&self, fut: Pin<Box<dyn Future<Output = Out> + Send + 'static>>) -> Pin<Box<dyn JoinHandle<Output = Result<Out, BoxedError>>>> {
+        Box::pin(BoxedErrorFuture(self.spawn(fut)))
+    }
+}
+
+impl<Out: 'static> AsyncRuntime<Out> for dyn AsyncRuntimeDyn<Out> {
+    type Err = BoxedError;
+    type JoinHandle = Pin<Box<dyn JoinHandle<Output = Result<Out, Self::Err>>>>;
+
+    fn spawn<Fut: Future<Output = Out> + Send + 'static>(&self, fut: Fut) -> Self::JoinHandle {
+        self.spawn_dyn(Box::pin(fut))
+    }
+}
+
+impl<Out, O> AsyncRuntime<Out> for Arc<O>
+where
+    O: AsyncRuntime<Out> + ?Sized,
+{
+    type Err = O::Err;
+    type JoinHandle = O::JoinHandle;
+
+    fn spawn<Fut: Future<Output = Out> + Send + 'static>(&self, fut: Fut) -> Self::JoinHandle {
+        O::spawn(self, fut)
+    }
+}
+
+pub struct BoxedError(pub Box<dyn Error + Send + 'static>);
+
+impl Debug for BoxedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Display for BoxedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Error for BoxedError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Error::source(&*self.0)
+    }
+}
+
+pub struct BoxedErrorFuture<T>(T);
+
+impl<T, O, E> Future for BoxedErrorFuture<T>
+where
+    T: Future<Output = Result<O, E>>,
+    E: Error + Send + 'static,
+{
+    type Output = Result<O, BoxedError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: fieldの値をclosure外部とやり取りしていないので安全
+        // ref: https://doc.rust-lang.org/std/pin/index.html#pinning-is-structural-for-field
+        let future = unsafe { self.map_unchecked_mut(|BoxedErrorFuture(f)| f) };
+        match future.poll(cx) {
+            Poll::Ready(Ok(value)) => Poll::Ready(Ok(value)),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(BoxedError(Box::new(err)))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T, O> JoinHandle for BoxedErrorFuture<T>
+where
+    T: JoinHandle,
+    BoxedErrorFuture<T>: Future<Output = Result<O, BoxedError>>,
+{
+    fn abort(&self) {
+        self.0.abort()
+    }
+
+    fn is_finished(&self) -> bool {
+        self.0.is_finished()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn assert_runtime<T: AsyncRuntime<()>>() {}
+
+    fn assert_runtime_clone<T: AsyncRuntime<()> + Clone>() {}
+
+    #[test]
+    fn test() {
+        assert_runtime::<Arc<dyn AsyncRuntimeDyn<()>>>();
+        assert_runtime_clone::<Arc<dyn AsyncRuntimeDyn<()>>>();
+    }
+}

--- a/mpdelta_core/Cargo.toml
+++ b/mpdelta_core/Cargo.toml
@@ -17,3 +17,4 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 regex = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/mpdelta_dyn_usecase/Cargo.toml
+++ b/mpdelta_dyn_usecase/Cargo.toml
@@ -1,20 +1,13 @@
 [package]
-name = "mpdelta_gui"
+name = "mpdelta_dyn_usecase"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arc-swap = { workspace = true }
-bitflags = { workspace = true }
-cgmath = { workspace = true }
-dashmap = { workspace = true }
-egui = { workspace = true }
+async-trait = { workspace = true }
 futures = { workspace = true }
-mpdelta_async_runtime = { workspace = true }
 mpdelta_core = { workspace = true }
-once_cell = { workspace = true }
 qcell = { workspace = true }
-regex = { workspace = true }
 tokio = { workspace = true }

--- a/mpdelta_dyn_usecase/src/lib.rs
+++ b/mpdelta_dyn_usecase/src/lib.rs
@@ -1,0 +1,551 @@
+use async_trait::async_trait;
+use futures::{FutureExt, TryFutureExt};
+use mpdelta_core::component::class::ComponentClass;
+use mpdelta_core::component::instance::ComponentInstance;
+use mpdelta_core::component::parameter::{Parameter, ParameterSelect, ParameterValueType};
+use mpdelta_core::core::EditEventListener;
+use mpdelta_core::edit::{InstanceEditCommand, RootComponentEditCommand};
+use mpdelta_core::project::{Project, RootComponentClass};
+use mpdelta_core::ptr::StaticPointer;
+use mpdelta_core::usecase::{
+    EditUsecase, GetAvailableComponentClassesUsecase, GetLoadedProjectsUsecase, GetRootComponentClassesUsecase, LoadProjectUsecase, NewProjectUsecase, NewRootComponentClassUsecase, RealtimeComponentRenderer, RealtimeRenderComponentUsecase, RedoUsecase, SetOwnerForRootComponentClassUsecase,
+    SubscribeEditEventUsecase, UndoUsecase, WriteProjectUsecase,
+};
+use qcell::TCell;
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use tokio::sync::RwLock;
+
+pub struct DynError(pub Box<dyn Error + 'static>);
+
+impl Debug for DynError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Display for DynError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Error for DynError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Error::source(&*self.0)
+    }
+}
+
+pub trait LoadProjectUsecaseDyn<K, T>: Send + Sync {
+    fn load_project_dyn<'life0, 'life1, 'async_trait>(&'life0 self, path: &'life1 Path) -> Pin<Box<dyn Future<Output = Result<StaticPointer<RwLock<Project<K, T>>>, Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait;
+}
+
+impl<K, T, O> LoadProjectUsecaseDyn<K, T> for O
+where
+    O: LoadProjectUsecase<K, T>,
+{
+    fn load_project_dyn<'life0, 'life1, 'async_trait>(&'life0 self, path: &'life1 Path) -> Pin<Box<dyn Future<Output = Result<StaticPointer<RwLock<Project<K, T>>>, Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+    {
+        Box::pin(async move { self.load_project(path).map_err(|err| Box::new(err) as Box<dyn Error + 'static>).await })
+    }
+}
+
+#[async_trait]
+impl<K, T> LoadProjectUsecase<K, T> for dyn LoadProjectUsecaseDyn<K, T> + Send + Sync {
+    type Err = DynError;
+
+    async fn load_project(&self, path: impl AsRef<Path> + Send + Sync) -> Result<StaticPointer<RwLock<Project<K, T>>>, Self::Err> {
+        self.load_project_dyn(path.as_ref()).map_err(DynError).await
+    }
+}
+
+pub trait WriteProjectUsecaseDyn<K, T>: Send + Sync {
+    fn write_project_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, project: &'life1 StaticPointer<RwLock<Project<K, T>>>, path: &'life2 Path) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait;
+}
+
+impl<K, T, O> WriteProjectUsecaseDyn<K, T> for O
+where
+    O: WriteProjectUsecase<K, T>,
+{
+    fn write_project_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, project: &'life1 StaticPointer<RwLock<Project<K, T>>>, path: &'life2 Path) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+    {
+        Box::pin(async move { self.write_project(project, path).map_err(|err| Box::new(err) as Box<dyn Error + 'static>).await })
+    }
+}
+
+#[async_trait]
+impl<K, T> WriteProjectUsecase<K, T> for dyn WriteProjectUsecaseDyn<K, T> + Send + Sync {
+    type Err = DynError;
+
+    async fn write_project(&self, project: &StaticPointer<RwLock<Project<K, T>>>, path: impl AsRef<Path> + Send + Sync) -> Result<(), Self::Err> {
+        self.write_project_dyn(project, path.as_ref()).map_err(DynError).await
+    }
+}
+
+pub trait NewProjectUsecaseDyn<K, T>: Send + Sync {
+    fn new_project_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = StaticPointer<RwLock<Project<K, T>>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait;
+}
+
+impl<K, T, O> NewProjectUsecaseDyn<K, T> for O
+where
+    O: NewProjectUsecase<K, T>,
+{
+    fn new_project_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = StaticPointer<RwLock<Project<K, T>>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+    {
+        println!("new_project_dyn");
+        Box::pin(async move { self.new_project().await })
+    }
+}
+
+#[async_trait]
+impl<K, T> NewProjectUsecase<K, T> for dyn NewProjectUsecaseDyn<K, T> + Send + Sync {
+    async fn new_project(&self) -> StaticPointer<RwLock<Project<K, T>>> {
+        self.new_project_dyn().await
+    }
+}
+
+pub trait NewRootComponentClassUsecaseDyn<K, T>: Send + Sync {
+    fn new_root_component_class_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = StaticPointer<RwLock<RootComponentClass<K, T>>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait;
+}
+
+impl<K, T, O> NewRootComponentClassUsecaseDyn<K, T> for O
+where
+    O: NewRootComponentClassUsecase<K, T>,
+{
+    fn new_root_component_class_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = StaticPointer<RwLock<RootComponentClass<K, T>>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+    {
+        Box::pin(async move { self.new_root_component_class().await })
+    }
+}
+
+#[async_trait]
+impl<K, T> NewRootComponentClassUsecase<K, T> for dyn NewRootComponentClassUsecaseDyn<K, T> + Send + Sync {
+    async fn new_root_component_class(&self) -> StaticPointer<RwLock<RootComponentClass<K, T>>> {
+        self.new_root_component_class_dyn().await
+    }
+}
+
+pub trait SetOwnerForRootComponentClassUsecaseDyn<K, T>: Send + Sync {
+    fn set_owner_for_root_component_class_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, owner: &'life2 StaticPointer<RwLock<Project<K, T>>>) -> Pin<Box<dyn Future<Output = ()> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait;
+}
+
+impl<K, T, O> SetOwnerForRootComponentClassUsecaseDyn<K, T> for O
+where
+    O: SetOwnerForRootComponentClassUsecase<K, T>,
+{
+    fn set_owner_for_root_component_class_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, owner: &'life2 StaticPointer<RwLock<Project<K, T>>>) -> Pin<Box<dyn Future<Output = ()> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+    {
+        Box::pin(async move { self.set_owner_for_root_component_class(component, owner).await })
+    }
+}
+
+#[async_trait]
+impl<K, T> SetOwnerForRootComponentClassUsecase<K, T> for dyn SetOwnerForRootComponentClassUsecaseDyn<K, T> + Send + Sync {
+    async fn set_owner_for_root_component_class(&self, component: &StaticPointer<RwLock<RootComponentClass<K, T>>>, owner: &StaticPointer<RwLock<Project<K, T>>>) {
+        self.set_owner_for_root_component_class_dyn(component, owner).await
+    }
+}
+
+pub trait GetLoadedProjectsUsecaseDyn<K, T>: Send + Sync {
+    fn get_loaded_projects_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = Cow<'_, [StaticPointer<RwLock<Project<K, T>>>]>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait;
+}
+
+impl<K, T, O> GetLoadedProjectsUsecaseDyn<K, T> for O
+where
+    O: GetLoadedProjectsUsecase<K, T>,
+{
+    fn get_loaded_projects_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = Cow<'_, [StaticPointer<RwLock<Project<K, T>>>]>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+    {
+        Box::pin(async move { self.get_loaded_projects().await })
+    }
+}
+
+#[async_trait]
+impl<K, T> GetLoadedProjectsUsecase<K, T> for dyn GetLoadedProjectsUsecaseDyn<K, T> + Send + Sync {
+    async fn get_loaded_projects(&self) -> Cow<[StaticPointer<RwLock<Project<K, T>>>]> {
+        self.get_loaded_projects_dyn().await
+    }
+}
+
+pub trait GetRootComponentClassesUsecaseDyn<K, T>: Send + Sync {
+    fn get_root_component_classes_dyn<'life0, 'life1, 'async_trait>(&'life0 self, project: &'life1 StaticPointer<RwLock<Project<K, T>>>) -> Pin<Box<dyn Future<Output = Cow<'_, [StaticPointer<RwLock<RootComponentClass<K, T>>>]>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait;
+}
+
+impl<K, T, O> GetRootComponentClassesUsecaseDyn<K, T> for O
+where
+    O: GetRootComponentClassesUsecase<K, T>,
+{
+    fn get_root_component_classes_dyn<'life0, 'life1, 'async_trait>(&'life0 self, project: &'life1 StaticPointer<RwLock<Project<K, T>>>) -> Pin<Box<dyn Future<Output = Cow<'_, [StaticPointer<RwLock<RootComponentClass<K, T>>>]>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+    {
+        Box::pin(async move { self.get_root_component_classes(project).await })
+    }
+}
+
+#[async_trait]
+impl<K, T> GetRootComponentClassesUsecase<K, T> for dyn GetRootComponentClassesUsecaseDyn<K, T> + Send + Sync {
+    async fn get_root_component_classes(&self, project: &StaticPointer<RwLock<Project<K, T>>>) -> Cow<[StaticPointer<RwLock<RootComponentClass<K, T>>>]> {
+        self.get_root_component_classes_dyn(project).await
+    }
+}
+
+pub trait GetAvailableComponentClassesUsecaseDyn<K, T>: Send + Sync {
+    fn get_available_component_classes_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = Cow<'_, [StaticPointer<RwLock<dyn ComponentClass<K, T>>>]>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait;
+}
+
+impl<K, T, O> GetAvailableComponentClassesUsecaseDyn<K, T> for O
+where
+    O: GetAvailableComponentClassesUsecase<K, T>,
+{
+    fn get_available_component_classes_dyn<'life0, 'async_trait>(&'life0 self) -> Pin<Box<dyn Future<Output = Cow<'_, [StaticPointer<RwLock<dyn ComponentClass<K, T>>>]>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+    {
+        Box::pin(async move { self.get_available_component_classes().await })
+    }
+}
+
+#[async_trait]
+impl<K, T> GetAvailableComponentClassesUsecase<K, T> for dyn GetAvailableComponentClassesUsecaseDyn<K, T> + Send + Sync {
+    async fn get_available_component_classes(&self) -> Cow<[StaticPointer<RwLock<dyn ComponentClass<K, T>>>]> {
+        self.get_available_component_classes_dyn().await
+    }
+}
+
+pub trait RealtimeComponentRendererDyn<T: ParameterValueType>: Send + Sync {
+    fn get_frame_count_dyn(&self) -> usize;
+    fn render_frame_dyn(&self, frame: usize) -> Result<T::Image, Box<dyn Error + 'static>>;
+    fn sampling_rate_dyn(&self) -> u32;
+    fn mix_audio_dyn(&self, offset: usize, length: usize) -> Result<T::Audio, Box<dyn Error + 'static>>;
+    fn render_param_dyn(&self, param: Parameter<ParameterSelect>) -> Result<Parameter<T>, Box<dyn Error + 'static>>;
+}
+
+impl<T: ParameterValueType, O> RealtimeComponentRendererDyn<T> for O
+where
+    O: RealtimeComponentRenderer<T>,
+{
+    fn get_frame_count_dyn(&self) -> usize {
+        self.get_frame_count()
+    }
+
+    fn render_frame_dyn(&self, frame: usize) -> Result<T::Image, Box<dyn Error + 'static>> {
+        self.render_frame(frame).map_err(|err| Box::new(err) as Box<dyn Error + 'static>)
+    }
+
+    fn sampling_rate_dyn(&self) -> u32 {
+        self.sampling_rate()
+    }
+
+    fn mix_audio_dyn(&self, offset: usize, length: usize) -> Result<T::Audio, Box<dyn Error + 'static>> {
+        self.mix_audio(offset, length).map_err(|err| Box::new(err) as Box<dyn Error + 'static>)
+    }
+
+    fn render_param_dyn(&self, param: Parameter<ParameterSelect>) -> Result<Parameter<T>, Box<dyn Error + 'static>> {
+        self.render_param(param).map_err(|err| Box::new(err) as Box<dyn Error + 'static>)
+    }
+}
+
+impl<T: ParameterValueType> RealtimeComponentRenderer<T> for dyn RealtimeComponentRendererDyn<T> + Send + Sync {
+    type Err = DynError;
+
+    fn get_frame_count(&self) -> usize {
+        self.get_frame_count_dyn()
+    }
+
+    fn render_frame(&self, frame: usize) -> Result<T::Image, Self::Err> {
+        self.render_frame_dyn(frame).map_err(DynError)
+    }
+
+    fn sampling_rate(&self) -> u32 {
+        self.sampling_rate_dyn()
+    }
+
+    fn mix_audio(&self, offset: usize, length: usize) -> Result<T::Audio, Self::Err> {
+        self.mix_audio_dyn(offset, length).map_err(DynError)
+    }
+
+    fn render_param(&self, param: Parameter<ParameterSelect>) -> Result<Parameter<T>, Self::Err> {
+        self.render_param_dyn(param).map_err(DynError)
+    }
+}
+
+pub trait RealtimeRenderComponentUsecaseDyn<K, T: ParameterValueType>: Send + Sync {
+    fn render_component_dyn<'life0, 'life1, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> Pin<Box<dyn Future<Output = Result<Box<dyn RealtimeComponentRendererDyn<T> + Send + Sync + 'static>, Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait;
+}
+
+impl<K, T, O> RealtimeRenderComponentUsecaseDyn<K, T> for O
+where
+    T: ParameterValueType,
+    O: RealtimeRenderComponentUsecase<K, T>,
+{
+    fn render_component_dyn<'life0, 'life1, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> Pin<Box<dyn Future<Output = Result<Box<dyn RealtimeComponentRendererDyn<T> + Send + Sync + 'static>, Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+    {
+        Box::pin(async move {
+            self.render_component(component)
+                .map(|result| match result {
+                    Ok(renderer) => Ok(Box::new(renderer) as Box<dyn RealtimeComponentRendererDyn<T> + Send + Sync + 'static>),
+                    Err(err) => Err(Box::new(err) as Box<dyn Error + 'static>),
+                })
+                .await
+        })
+    }
+}
+
+#[async_trait]
+impl<K, T: ParameterValueType> RealtimeRenderComponentUsecase<K, T> for dyn RealtimeRenderComponentUsecaseDyn<K, T> + Send + Sync {
+    type Err = DynError;
+    type Renderer = Box<dyn RealtimeComponentRendererDyn<T> + Send + Sync + 'static>;
+
+    async fn render_component(&self, component: &StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> Result<Self::Renderer, Self::Err> {
+        self.render_component_dyn(component).map_err(DynError).await
+    }
+}
+
+pub trait EditUsecaseDyn<K, T>: Send + Sync {
+    fn edit_dyn<'life0, 'life1, 'async_trait>(&'life0 self, target: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, command: RootComponentEditCommand<K, T>) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait;
+    fn edit_instance_dyn<'life0, 'life1, 'life2, 'async_trait>(
+        &'life0 self,
+        root: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>,
+        target: &'life2 StaticPointer<TCell<K, ComponentInstance<K, T>>>,
+        command: InstanceEditCommand<K, T>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait;
+}
+
+impl<K, T, O> EditUsecaseDyn<K, T> for O
+where
+    O: EditUsecase<K, T>,
+{
+    fn edit_dyn<'life0, 'life1, 'async_trait>(&'life0 self, target: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, command: RootComponentEditCommand<K, T>) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+    {
+        Box::pin(async move { self.edit(target, command).map_err(|err| Box::new(err) as Box<dyn Error + 'static>).await })
+    }
+
+    fn edit_instance_dyn<'life0, 'life1, 'life2, 'async_trait>(
+        &'life0 self,
+        root: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>,
+        target: &'life2 StaticPointer<TCell<K, ComponentInstance<K, T>>>,
+        command: InstanceEditCommand<K, T>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + 'static>>> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+    {
+        Box::pin(async move { self.edit_instance(root, target, command).map_err(|err| Box::new(err) as Box<dyn Error + 'static>).await })
+    }
+}
+
+#[async_trait]
+impl<K, T> EditUsecase<K, T> for dyn EditUsecaseDyn<K, T> + Send + Sync {
+    type Err = DynError;
+
+    async fn edit(&self, target: &StaticPointer<RwLock<RootComponentClass<K, T>>>, command: RootComponentEditCommand<K, T>) -> Result<(), Self::Err> {
+        self.edit_dyn(target, command).map_err(DynError).await
+    }
+
+    async fn edit_instance(&self, root: &StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &StaticPointer<TCell<K, ComponentInstance<K, T>>>, command: InstanceEditCommand<K, T>) -> Result<(), Self::Err> {
+        self.edit_instance_dyn(root, target, command).map_err(DynError).await
+    }
+}
+
+pub trait SubscribeEditEventUsecaseDyn<K, T>: Send + Sync {
+    fn add_edit_event_listener_dyn(&self, listener: Box<dyn EditEventListener<K, T> + 'static>) -> Box<dyn Send + Sync>;
+}
+
+impl<K: 'static, T: 'static, O> SubscribeEditEventUsecaseDyn<K, T> for O
+where
+    O: SubscribeEditEventUsecase<K, T>,
+{
+    fn add_edit_event_listener_dyn(&self, listener: Box<dyn EditEventListener<K, T> + 'static>) -> Box<dyn Send + Sync> {
+        Box::new(self.add_edit_event_listener(listener))
+    }
+}
+
+impl<K, T> SubscribeEditEventUsecase<K, T> for dyn SubscribeEditEventUsecaseDyn<K, T> + Send + Sync {
+    type EditEventListenerGuard = Box<dyn Send + Sync>;
+
+    fn add_edit_event_listener(&self, listener: impl EditEventListener<K, T> + 'static) -> Self::EditEventListenerGuard {
+        self.add_edit_event_listener_dyn(Box::new(listener))
+    }
+}
+
+pub trait UndoUsecaseDyn<K, T>: Send + Sync {
+    fn undo_dyn<'life0, 'life1, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait;
+    fn undo_instance_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, root: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &'life2 StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait;
+}
+
+impl<K, T, O> UndoUsecaseDyn<K, T> for O
+where
+    O: UndoUsecase<K, T>,
+{
+    fn undo_dyn<'life0, 'life1, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+    {
+        Box::pin(async move { self.undo(component).await })
+    }
+
+    fn undo_instance_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, root: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &'life2 StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+    {
+        Box::pin(async move { self.undo_instance(root, target).await })
+    }
+}
+
+#[async_trait]
+impl<K, T> UndoUsecase<K, T> for dyn UndoUsecaseDyn<K, T> + Send + Sync {
+    async fn undo(&self, component: &StaticPointer<RwLock<RootComponentClass<K, T>>>) -> bool {
+        self.undo_dyn(component).await
+    }
+
+    async fn undo_instance(&self, root: &StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> bool {
+        self.undo_instance_dyn(root, target).await
+    }
+}
+
+pub trait RedoUsecaseDyn<K, T>: Send + Sync {
+    fn redo_dyn<'life0, 'life1, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait;
+    fn redo_instance_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, root: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &'life2 StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait;
+}
+
+impl<K, T, O> RedoUsecaseDyn<K, T> for O
+where
+    O: RedoUsecase<K, T>,
+{
+    fn redo_dyn<'life0, 'life1, 'async_trait>(&'life0 self, component: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+    {
+        Box::pin(async move { self.redo(component).await })
+    }
+
+    fn redo_instance_dyn<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, root: &'life1 StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &'life2 StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> Pin<Box<dyn Future<Output = bool> + Send + 'async_trait>>
+    where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+    {
+        Box::pin(async move { self.redo_instance(root, target).await })
+    }
+}
+
+#[async_trait]
+impl<K, T> RedoUsecase<K, T> for dyn RedoUsecaseDyn<K, T> + Send + Sync {
+    async fn redo(&self, component: &StaticPointer<RwLock<RootComponentClass<K, T>>>) -> bool {
+        self.redo_dyn(component).await
+    }
+
+    async fn redo_instance(&self, root: &StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &StaticPointer<TCell<K, ComponentInstance<K, T>>>) -> bool {
+        self.redo_instance_dyn(root, target).await
+    }
+}

--- a/mpdelta_gui/src/edit_funnel.rs
+++ b/mpdelta_gui/src/edit_funnel.rs
@@ -1,4 +1,4 @@
-use crate::global_ui_state::GlobalUIEventHandler;
+use mpdelta_async_runtime::AsyncRuntime;
 use mpdelta_core::component::instance::ComponentInstance;
 use mpdelta_core::component::parameter::ParameterValueType;
 use mpdelta_core::edit::{InstanceEditCommand, RootComponentEditCommand};
@@ -7,16 +7,15 @@ use mpdelta_core::ptr::StaticPointer;
 use mpdelta_core::usecase::EditUsecase;
 use qcell::TCell;
 use std::sync::Arc;
-use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
-pub struct EditFunnelImpl<Edit> {
+pub struct EditFunnelImpl<Edit, Runtime> {
     edit: Arc<Edit>,
-    handle: Handle,
+    handle: Runtime,
 }
 
-impl EditFunnelImpl<()> {
-    pub fn new<K: 'static, T, Edit: EditUsecase<K, T> + 'static>(handle: Handle, edit: Arc<Edit>) -> Arc<EditFunnelImpl<Edit>> {
+impl EditFunnelImpl<(), ()> {
+    pub fn new<K: 'static, T, Edit: EditUsecase<K, T> + 'static, Runtime: AsyncRuntime<()>>(handle: Runtime, edit: Arc<Edit>) -> Arc<EditFunnelImpl<Edit, Runtime>> {
         Arc::new(EditFunnelImpl { edit, handle })
     }
 }
@@ -26,7 +25,7 @@ pub trait EditFunnel<K: 'static, T>: Send + Sync {
     fn edit_instance(&self, root: &StaticPointer<RwLock<RootComponentClass<K, T>>>, target: &StaticPointer<TCell<K, ComponentInstance<K, T>>>, command: InstanceEditCommand<K, T>);
 }
 
-impl<K: 'static, T: ParameterValueType, Edit: EditUsecase<K, T> + 'static> EditFunnel<K, T> for EditFunnelImpl<Edit> {
+impl<K: 'static, T: ParameterValueType, Edit: EditUsecase<K, T> + 'static, Runtime: AsyncRuntime<()>> EditFunnel<K, T> for EditFunnelImpl<Edit, Runtime> {
     fn edit(&self, target: &StaticPointer<RwLock<RootComponentClass<K, T>>>, command: RootComponentEditCommand<K, T>) {
         let edit = Arc::clone(&self.edit);
         let target = target.clone();

--- a/mpdelta_gui/src/lib.rs
+++ b/mpdelta_gui/src/lib.rs
@@ -17,7 +17,7 @@ pub trait ImageRegister<T> {
 
 impl<'a, I, T> ImageRegister<T> for &'a mut I
 where
-    I: ImageRegister<T>,
+    I: ImageRegister<T> + ?Sized,
 {
     fn register_image(&mut self, texture: T) -> TextureId {
         I::register_image(self, texture)

--- a/mpdelta_gui/src/message_router.rs
+++ b/mpdelta_gui/src/message_router.rs
@@ -1,73 +1,74 @@
-use crate::message_router::handler::empty::EmptyHandler;
+use crate::message_router::handler::empty::{EmptyHandler, EmptyHandlerBuilder};
 use crate::message_router::handler::PairHandler;
 use crate::message_router::static_cow::{Owned, StaticCow};
+use mpdelta_async_runtime::AsyncRuntime;
 use std::marker::PhantomData;
-use tokio::runtime::Handle;
 
 pub mod handler;
 mod static_cow;
 
 #[derive(Debug)]
-pub struct MessageRouter<Handler> {
+pub struct MessageRouter<Handler, Runtime> {
     handler: Handler,
-    runtime: Handle,
+    runtime: Runtime,
 }
 
-impl MessageRouter<EmptyHandler> {
-    pub fn builder<Message>() -> MessageRouterBuilder<Message, EmptyHandler> {
+impl MessageRouter<EmptyHandler, ()> {
+    pub fn builder<Message, Runtime>() -> MessageRouterBuilder<Message, Runtime, EmptyHandler> {
         MessageRouterBuilder::new()
     }
 }
 
-impl<Handler> MessageRouter<Handler> {
+impl<Handler, Runtime: AsyncRuntime<()> + Clone> MessageRouter<Handler, Runtime> {
     pub fn handle<Message>(&self, message: Message)
     where
         Message: Clone,
-        Handler: MessageHandler<Message>,
+        Handler: MessageHandler<Message, Runtime>,
     {
         self.handler.handle(Owned(message), &self.runtime);
     }
 }
 
 #[derive(Debug)]
-pub struct MessageRouterBuilder<Message, Handler> {
+pub struct MessageRouterBuilder<Message, Runtime, Handler> {
     handler: Handler,
-    _phantom: PhantomData<Message>,
+    _phantom: PhantomData<(Message, Runtime)>,
 }
 
-impl<Message> MessageRouterBuilder<Message, EmptyHandler> {
-    pub fn new() -> MessageRouterBuilder<Message, EmptyHandler> {
+impl<Message, Runtime> MessageRouterBuilder<Message, Runtime, EmptyHandler> {
+    pub fn new() -> MessageRouterBuilder<Message, Runtime, EmptyHandler> {
         MessageRouterBuilder { handler: EmptyHandler, _phantom: PhantomData }
     }
 }
 
-impl<Message, Handler: MessageHandler<Message>> MessageRouterBuilder<Message, Handler> {
-    pub fn handle<AdditionalHandler: MessageHandler<Message>>(self, handler: AdditionalHandler) -> MessageRouterBuilder<Message, PairHandler<AdditionalHandler, Handler>> {
+impl<Message, Runtime, Handler: MessageHandler<Message, Runtime>> MessageRouterBuilder<Message, Runtime, Handler> {
+    pub fn handle<AdditionalHandler: MessageHandler<Message, Runtime>>(self, handler_builder: impl FnOnce(EmptyHandlerBuilder<Runtime>) -> AdditionalHandler) -> MessageRouterBuilder<Message, Runtime, PairHandler<AdditionalHandler, Handler>> {
         let MessageRouterBuilder { handler: current_handler, _phantom } = self;
         MessageRouterBuilder {
-            handler: PairHandler(handler, current_handler),
+            handler: PairHandler(handler_builder(EmptyHandlerBuilder::new()), current_handler),
             _phantom,
         }
     }
 
-    pub fn build(self, runtime: Handle) -> MessageRouter<Handler> {
+    pub fn build(self, runtime: Runtime) -> MessageRouter<Handler, Runtime> {
         let MessageRouterBuilder { handler, .. } = self;
         MessageRouter { handler, runtime }
     }
 }
 
-pub trait MessageHandler<Message> {
-    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Handle);
+pub trait MessageHandler<Message, Runtime> {
+    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Runtime);
 }
 
 #[cfg(test)]
 mod tests {
     use super::handler::MessageHandlerBuilder;
     use super::*;
-    use crate::message_router::handler::IntoFunctionHandler;
+    use crate::message_router::handler::{IntoAsyncFunctionHandler, IntoAsyncFunctionHandlerSingle, IntoFunctionHandler};
     use std::sync::atomic::AtomicUsize;
     use std::sync::{atomic, Arc};
     use std::time::Duration;
+    use tokio::runtime::Handle;
     use tokio::sync::mpsc::error::TryRecvError;
 
     #[test]
@@ -77,24 +78,30 @@ mod tests {
         let sum2 = Arc::new(AtomicUsize::new(0));
         let sum3 = Arc::new(AtomicUsize::new(0));
         let message_router = MessageRouter::builder()
-            .handle(handler::handle({
-                let sum1 = Arc::clone(&sum1);
-                move |message: usize| {
-                    sum1.fetch_add(message, atomic::Ordering::SeqCst);
-                }
-            }))
-            .handle(handler::handle({
-                let sum2 = Arc::clone(&sum2);
-                move |message: usize| {
-                    sum2.fetch_add(message * 2, atomic::Ordering::SeqCst);
-                }
-            }))
-            .handle(handler::handle({
-                let sum3 = Arc::clone(&sum3);
-                move |message: usize| {
-                    sum3.fetch_add(message * 3, atomic::Ordering::SeqCst);
-                }
-            }))
+            .handle(|handler| {
+                handler.handle({
+                    let sum1 = Arc::clone(&sum1);
+                    move |message: usize| {
+                        sum1.fetch_add(message, atomic::Ordering::SeqCst);
+                    }
+                })
+            })
+            .handle(|handler| {
+                handler.handle({
+                    let sum2 = Arc::clone(&sum2);
+                    move |message: usize| {
+                        sum2.fetch_add(message * 2, atomic::Ordering::SeqCst);
+                    }
+                })
+            })
+            .handle(|handler| {
+                handler.handle({
+                    let sum3 = Arc::clone(&sum3);
+                    move |message: usize| {
+                        sum3.fetch_add(message * 3, atomic::Ordering::SeqCst);
+                    }
+                })
+            })
             .build(runtime.handle().clone());
         message_router.handle(1);
         assert_eq!(sum1.load(atomic::Ordering::SeqCst), 1);
@@ -115,9 +122,11 @@ mod tests {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let sum = AtomicUsize::new(0);
         let message_router = MessageRouter::builder()
-            .handle(handler::filter_map(|f| Some(f as i32)).map(|i| i as i8).filter_map(|i| Some(i as u64)).map(|i| i as usize).handle(|i| {
-                sum.fetch_add(i, atomic::Ordering::SeqCst);
-            }))
+            .handle(|handler| {
+                handler.filter_map(|f| Some(f as i32)).map(|i| i as i8).filter_map(|i| Some(i as u64)).map(|i| i as usize).handle(|i| {
+                    sum.fetch_add(i, atomic::Ordering::SeqCst);
+                })
+            })
             .build(runtime.handle().clone());
         message_router.handle(1.0);
         assert_eq!(sum.load(atomic::Ordering::SeqCst), 1);
@@ -130,15 +139,21 @@ mod tests {
         let sum2 = AtomicUsize::new(0);
         let sum3 = AtomicUsize::new(0);
         let message_router = MessageRouter::builder()
-            .handle(handler::handle(|message: usize| {
-                sum1.fetch_add(message, atomic::Ordering::SeqCst);
-            }))
-            .handle(handler::filter(|&m| m >= 10).handle(|message: usize| {
-                sum2.fetch_add(message, atomic::Ordering::SeqCst);
-            }))
-            .handle(handler::filter_map(|m| (m < 10).then_some(m)).handle(|message: usize| {
-                sum3.fetch_add(message, atomic::Ordering::SeqCst);
-            }))
+            .handle(|handler| {
+                handler.handle(|message: usize| {
+                    sum1.fetch_add(message, atomic::Ordering::SeqCst);
+                })
+            })
+            .handle(|handler| {
+                handler.filter(|&m| m >= 10).handle(|message: usize| {
+                    sum2.fetch_add(message, atomic::Ordering::SeqCst);
+                })
+            })
+            .handle(|handler| {
+                handler.filter_map(|m| (m < 10).then_some(m)).handle(|message: usize| {
+                    sum3.fetch_add(message, atomic::Ordering::SeqCst);
+                })
+            })
             .build(runtime.handle().clone());
         message_router.handle(1);
         assert_eq!(sum1.load(atomic::Ordering::SeqCst), 1);
@@ -174,19 +189,23 @@ mod tests {
         let update_lock_receiver = Arc::new(tokio::sync::Mutex::new(update_lock_receiver));
         let (update_event_sender, mut update_event_receiver) = tokio::sync::mpsc::unbounded_channel();
         let message_router = MessageRouter::builder()
-            .handle(handler::handle(|message: usize| {
-                sum1.fetch_add(message, atomic::Ordering::SeqCst);
-            }))
-            .handle(handler::handle_async(|message: usize| {
-                let update_lock_receiver = Arc::clone(&update_lock_receiver);
-                let sum2 = Arc::clone(&sum2);
-                let update_event_sender = update_event_sender.clone();
-                async move {
-                    update_lock_receiver.lock().await.recv().await.unwrap();
-                    sum2.fetch_add(message, atomic::Ordering::SeqCst);
-                    update_event_sender.send(()).unwrap();
-                }
-            }))
+            .handle(|handler| {
+                handler.handle(|message: usize| {
+                    sum1.fetch_add(message, atomic::Ordering::SeqCst);
+                })
+            })
+            .handle(|handler| {
+                handler.handle_async(|message: usize| {
+                    let update_lock_receiver = Arc::clone(&update_lock_receiver);
+                    let sum2 = Arc::clone(&sum2);
+                    let update_event_sender = update_event_sender.clone();
+                    async move {
+                        update_lock_receiver.lock().await.recv().await.unwrap();
+                        sum2.fetch_add(message, atomic::Ordering::SeqCst);
+                        update_event_sender.send(()).unwrap();
+                    }
+                })
+            })
             .build(Handle::current());
         message_router.handle(1);
         assert_eq!(sum1.load(atomic::Ordering::SeqCst), 1);
@@ -213,24 +232,26 @@ mod tests {
         let (update_lock_sender, mut update_lock_receiver) = tokio::sync::mpsc::unbounded_channel::<()>();
         let (end_process_sender, end_process_receiver) = tokio::sync::broadcast::channel::<()>(16);
         let message_router = MessageRouter::builder()
-            .handle(handler::handle_async_single(|mut message_receiver| {
-                let sum2 = Arc::clone(&sum);
-                let update_lock_sender = update_lock_sender.clone();
-                let mut end_process_receiver = end_process_receiver.resubscribe();
-                async move {
-                    loop {
-                        tokio::select! {
-                            Some(message) = message_receiver.get_message() => {
-                                sum2.fetch_add(message, atomic::Ordering::SeqCst);
-                                let _ = update_lock_sender.send(());
-                            }
-                            _ = end_process_receiver.recv() => {
-                                break
+            .handle(|handler| {
+                handler.handle_async_single(|mut message_receiver| {
+                    let sum2 = Arc::clone(&sum);
+                    let update_lock_sender = update_lock_sender.clone();
+                    let mut end_process_receiver = end_process_receiver.resubscribe();
+                    async move {
+                        loop {
+                            tokio::select! {
+                                Some(message) = message_receiver.get_message() => {
+                                    sum2.fetch_add(message, atomic::Ordering::SeqCst);
+                                    let _ = update_lock_sender.send(());
+                                }
+                                _ = end_process_receiver.recv() => {
+                                    break
+                                }
                             }
                         }
                     }
-                }
-            }))
+                })
+            })
             .build(Handle::current());
         message_router.handle(1);
         update_lock_receiver.recv().await;

--- a/mpdelta_gui/src/message_router/handler/empty.rs
+++ b/mpdelta_gui/src/message_router/handler/empty.rs
@@ -1,17 +1,24 @@
 use crate::message_router::handler::{IntoMessageHandler, MessageHandlerBuilder};
 use crate::message_router::static_cow::StaticCow;
 use crate::message_router::MessageHandler;
-use tokio::runtime::Handle;
+use mpdelta_async_runtime::AsyncRuntime;
+use std::marker::PhantomData;
 
 pub struct EmptyHandler;
 
-pub struct EmptyHandlerBuilder;
+pub struct EmptyHandlerBuilder<Runtime>(PhantomData<Runtime>);
 
-impl<Message: Clone> MessageHandlerBuilder<Message> for EmptyHandlerBuilder {
+impl<Runtime> EmptyHandlerBuilder<Runtime> {
+    pub(in crate::message_router) fn new() -> EmptyHandlerBuilder<Runtime> {
+        EmptyHandlerBuilder(PhantomData)
+    }
+}
+
+impl<Message: Clone, Runtime> MessageHandlerBuilder<Message, Runtime> for EmptyHandlerBuilder<Runtime> {
     type OutMessage = Message;
 }
 
-impl<Message: Clone, Tail: MessageHandler<Message>> IntoMessageHandler<Message, Tail> for EmptyHandlerBuilder {
+impl<Message: Clone, Runtime: AsyncRuntime<()> + Clone, Tail: MessageHandler<Message, Runtime>> IntoMessageHandler<Message, Runtime, Tail> for EmptyHandlerBuilder<Runtime> {
     type Out = Tail;
 
     fn into_message_handler(self, tail: Tail) -> Self::Out {
@@ -19,6 +26,6 @@ impl<Message: Clone, Tail: MessageHandler<Message>> IntoMessageHandler<Message, 
     }
 }
 
-impl<Message: Clone> MessageHandler<Message> for EmptyHandler {
-    fn handle<MessageValue: StaticCow<Message>>(&self, _message: MessageValue, _runtime: &Handle) {}
+impl<Message: Clone, Runtime: AsyncRuntime<()> + Clone> MessageHandler<Message, Runtime> for EmptyHandler {
+    fn handle<MessageValue: StaticCow<Message>>(&self, _message: MessageValue, _runtime: &Runtime) {}
 }

--- a/mpdelta_gui/src/message_router/handler/filter.rs
+++ b/mpdelta_gui/src/message_router/handler/filter.rs
@@ -1,54 +1,59 @@
 use crate::message_router::handler::{IntoMessageHandler, MessageHandler, MessageHandlerBuilder};
 use crate::message_router::static_cow::StaticCow;
-use tokio::runtime::Handle;
+use mpdelta_async_runtime::AsyncRuntime;
+use std::marker::PhantomData;
 
 pub struct Filter<F, T> {
     filter: F,
     tail: T,
 }
 
-pub struct FilterBuilder<P, F> {
+pub struct FilterBuilder<P, F, Runtime> {
     prev: P,
     filter: F,
+    _phantom: PhantomData<Runtime>,
 }
 
-impl<P, F> FilterBuilder<P, F> {
+impl<P, F, Runtime> FilterBuilder<P, F, Runtime> {
     pub(in crate::message_router::handler) fn new(prev: P, filter: F) -> Self {
-        FilterBuilder { prev, filter }
+        FilterBuilder { prev, filter, _phantom: PhantomData }
     }
 }
 
-impl<Message, P, F> MessageHandlerBuilder<Message> for FilterBuilder<P, F>
+impl<Message, P, F, Runtime> MessageHandlerBuilder<Message, Runtime> for FilterBuilder<P, F, Runtime>
 where
     Message: Clone,
-    P: MessageHandlerBuilder<Message>,
+    P: MessageHandlerBuilder<Message, Runtime>,
     F: Fn(&P::OutMessage) -> bool,
+    Runtime: AsyncRuntime<()> + Clone,
 {
     type OutMessage = P::OutMessage;
 }
 
-impl<Message, Tail, P, F> IntoMessageHandler<Message, Tail> for FilterBuilder<P, F>
+impl<Message, Runtime, Tail, P, F> IntoMessageHandler<Message, Runtime, Tail> for FilterBuilder<P, F, Runtime>
 where
     Message: Clone,
-    Tail: MessageHandler<P::OutMessage>,
-    P: IntoMessageHandler<Message, Filter<F, Tail>>,
+    Runtime: AsyncRuntime<()> + Clone,
+    Tail: MessageHandler<P::OutMessage, Runtime>,
+    P: IntoMessageHandler<Message, Runtime, Filter<F, Tail>>,
     F: Fn(&P::OutMessage) -> bool,
 {
     type Out = P::Out;
 
     fn into_message_handler(self, tail: Tail) -> Self::Out {
-        let FilterBuilder { prev, filter } = self;
+        let FilterBuilder { prev, filter, _phantom } = self;
         prev.into_message_handler(Filter { filter, tail })
     }
 }
 
-impl<Message, F, T> MessageHandler<Message> for Filter<F, T>
+impl<Message, Runtime, F, T> MessageHandler<Message, Runtime> for Filter<F, T>
 where
     Message: Clone,
+    Runtime: AsyncRuntime<()> + Clone,
     F: Fn(&Message) -> bool,
-    T: MessageHandler<Message>,
+    T: MessageHandler<Message, Runtime>,
 {
-    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Handle) {
+    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Runtime) {
         let Filter { filter, tail } = self;
         if message.with_ref(filter) {
             tail.handle(message, runtime);

--- a/mpdelta_gui/src/message_router/handler/filter_map.rs
+++ b/mpdelta_gui/src/message_router/handler/filter_map.rs
@@ -1,57 +1,61 @@
 use crate::message_router::handler::{IntoMessageHandler, MessageHandler, MessageHandlerBuilder};
 use crate::message_router::static_cow::{Owned, StaticCow};
-use tokio::runtime::Handle;
+use mpdelta_async_runtime::AsyncRuntime;
+use std::marker::PhantomData;
 
 pub struct FilterMap<F, T> {
     filter: F,
     tail: T,
 }
 
-pub struct FilterMapBuilder<P, F> {
+pub struct FilterMapBuilder<P, F, Runtime> {
     prev: P,
     filter: F,
+    _phantom: PhantomData<Runtime>,
 }
 
-impl<P, F> FilterMapBuilder<P, F> {
+impl<P, F, Runtime> FilterMapBuilder<P, F, Runtime> {
     pub(super) fn new(prev: P, filter: F) -> Self {
-        FilterMapBuilder { prev, filter }
+        FilterMapBuilder { prev, filter, _phantom: PhantomData }
     }
 }
 
-impl<Message, P, F, Out> MessageHandlerBuilder<Message> for FilterMapBuilder<P, F>
+impl<Message, Runtime, P, F, Out> MessageHandlerBuilder<Message, Runtime> for FilterMapBuilder<P, F, Runtime>
 where
     Message: Clone,
     Out: Clone,
-    P: MessageHandlerBuilder<Message>,
+    P: MessageHandlerBuilder<Message, Runtime>,
     F: Fn(P::OutMessage) -> Option<Out>,
 {
     type OutMessage = Out;
 }
 
-impl<Message, Tail, P, F, Out> IntoMessageHandler<Message, Tail> for FilterMapBuilder<P, F>
+impl<Message, Runtime, Tail, P, F, Out> IntoMessageHandler<Message, Runtime, Tail> for FilterMapBuilder<P, F, Runtime>
 where
     Message: Clone,
-    Tail: MessageHandler<Out>,
+    Runtime: AsyncRuntime<()> + Clone,
+    Tail: MessageHandler<Out, Runtime>,
     Out: Clone,
-    P: IntoMessageHandler<Message, FilterMap<F, Tail>>,
+    P: IntoMessageHandler<Message, Runtime, FilterMap<F, Tail>>,
     F: Fn(P::OutMessage) -> Option<Out>,
 {
     type Out = P::Out;
 
     fn into_message_handler(self, tail: Tail) -> Self::Out {
-        let FilterMapBuilder { prev, filter } = self;
+        let FilterMapBuilder { prev, filter, _phantom } = self;
         prev.into_message_handler(FilterMap { filter, tail })
     }
 }
 
-impl<Message, F, T, O> MessageHandler<Message> for FilterMap<F, T>
+impl<Message, Runtime, F, T, O> MessageHandler<Message, Runtime> for FilterMap<F, T>
 where
     Message: Clone,
+    Runtime: AsyncRuntime<()> + Clone,
     O: Clone,
     F: Fn(Message) -> Option<O>,
-    T: MessageHandler<O>,
+    T: MessageHandler<O, Runtime>,
 {
-    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Handle) {
+    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Runtime) {
         let FilterMap { filter, tail } = self;
         let Some(message) = filter(message.into_owned()) else {
             return;

--- a/mpdelta_gui/src/message_router/handler/function.rs
+++ b/mpdelta_gui/src/message_router/handler/function.rs
@@ -1,15 +1,16 @@
 use crate::message_router::static_cow::StaticCow;
 use crate::message_router::MessageHandler;
-use tokio::runtime::Handle;
+use mpdelta_async_runtime::AsyncRuntime;
 
 pub struct FunctionHandler<F>(pub(super) F);
 
-impl<Message, F> MessageHandler<Message> for FunctionHandler<F>
+impl<Message, Runtime, F> MessageHandler<Message, Runtime> for FunctionHandler<F>
 where
     Message: Clone,
+    Runtime: AsyncRuntime<()> + Clone,
     F: Fn(Message),
 {
-    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, _runtime: &Handle) {
+    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, _runtime: &Runtime) {
         self.0(message.into_owned())
     }
 }

--- a/mpdelta_gui/src/message_router/handler/map.rs
+++ b/mpdelta_gui/src/message_router/handler/map.rs
@@ -1,57 +1,61 @@
 use crate::message_router::handler::{IntoMessageHandler, MessageHandler, MessageHandlerBuilder};
 use crate::message_router::static_cow::{Owned, StaticCow};
-use tokio::runtime::Handle;
+use mpdelta_async_runtime::AsyncRuntime;
+use std::marker::PhantomData;
 
 pub struct Map<F, T> {
     map: F,
     tail: T,
 }
 
-pub struct MapBuilder<P, F> {
+pub struct MapBuilder<P, F, Runtime> {
     prev: P,
     map: F,
+    _phantom: PhantomData<Runtime>,
 }
 
-impl<P, F> MapBuilder<P, F> {
+impl<P, F, Runtime> MapBuilder<P, F, Runtime> {
     pub(super) fn new(prev: P, map: F) -> Self {
-        MapBuilder { prev, map }
+        MapBuilder { prev, map, _phantom: PhantomData }
     }
 }
 
-impl<Message, P, F, O> MessageHandlerBuilder<Message> for MapBuilder<P, F>
+impl<Message, Runtime, P, F, O> MessageHandlerBuilder<Message, Runtime> for MapBuilder<P, F, Runtime>
 where
     Message: Clone,
     O: Clone,
-    P: MessageHandlerBuilder<Message>,
+    P: MessageHandlerBuilder<Message, Runtime>,
     F: Fn(P::OutMessage) -> O,
 {
     type OutMessage = O;
 }
 
-impl<Message, Tail, P, F, O> IntoMessageHandler<Message, Tail> for MapBuilder<P, F>
+impl<Message, Runtime, Tail, P, F, O> IntoMessageHandler<Message, Runtime, Tail> for MapBuilder<P, F, Runtime>
 where
     Message: Clone,
-    Tail: MessageHandler<O>,
+    Runtime: AsyncRuntime<()> + Clone,
+    Tail: MessageHandler<O, Runtime>,
     O: Clone,
-    P: IntoMessageHandler<Message, Map<F, Tail>>,
+    P: IntoMessageHandler<Message, Runtime, Map<F, Tail>>,
     F: Fn(P::OutMessage) -> O,
 {
     type Out = P::Out;
 
     fn into_message_handler(self, tail: Tail) -> Self::Out {
-        let MapBuilder { prev, map } = self;
+        let MapBuilder { prev, map, _phantom } = self;
         prev.into_message_handler(Map { map, tail })
     }
 }
 
-impl<Message, F, T, O> MessageHandler<Message> for Map<F, T>
+impl<Message, Runtime, F, T, O> MessageHandler<Message, Runtime> for Map<F, T>
 where
     Message: Clone,
+    Runtime: AsyncRuntime<()> + Clone,
     O: Clone,
     F: Fn(Message) -> O,
-    T: MessageHandler<O>,
+    T: MessageHandler<O, Runtime>,
 {
-    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Handle) {
+    fn handle<MessageValue: StaticCow<Message>>(&self, message: MessageValue, runtime: &Runtime) {
         let Map { map, tail } = self;
         let message = map(message.into_owned());
         tail.handle(Owned(message), runtime);

--- a/mpdelta_gui/src/message_router/handler/multiple.rs
+++ b/mpdelta_gui/src/message_router/handler/multiple.rs
@@ -1,30 +1,30 @@
-use crate::message_router::handler::empty::EmptyHandler;
+use crate::message_router::handler::empty::{EmptyHandler, EmptyHandlerBuilder};
 use crate::message_router::handler::{IntoMessageHandler, MessageHandler, PairHandler};
 use std::marker::PhantomData;
 
-pub struct MultipleBuilder<Message, P, T> {
+pub struct MultipleBuilder<Message, Runtime, P, T> {
     prev: P,
     tail: T,
-    _phantom: PhantomData<Message>,
+    _phantom: PhantomData<(Message, Runtime)>,
 }
 
-impl<Message, P> MultipleBuilder<Message, P, EmptyHandler> {
-    pub(super) fn new(prev: P) -> MultipleBuilder<Message, P, EmptyHandler> {
+impl<Message, Runtime, P> MultipleBuilder<Message, Runtime, P, EmptyHandler> {
+    pub(super) fn new(prev: P) -> MultipleBuilder<Message, Runtime, P, EmptyHandler> {
         MultipleBuilder { prev, tail: EmptyHandler, _phantom: PhantomData }
     }
 }
 
-impl<Message, P, T> MultipleBuilder<Message, P, T>
+impl<Message, Runtime, P, T> MultipleBuilder<Message, Runtime, P, T>
 where
     Message: Clone,
-    P: IntoMessageHandler<Message, T>,
-    T: MessageHandler<P::OutMessage>,
+    P: IntoMessageHandler<Message, Runtime, T>,
+    T: MessageHandler<P::OutMessage, Runtime>,
 {
-    pub fn handle<H: MessageHandler<P::OutMessage>>(self, additional_handler: H) -> MultipleBuilder<Message, P, PairHandler<T, H>> {
+    pub fn handle<H: MessageHandler<P::OutMessage, Runtime>>(self, additional_handler: impl FnOnce(EmptyHandlerBuilder<Runtime>) -> H) -> MultipleBuilder<Message, Runtime, P, PairHandler<T, H>> {
         let MultipleBuilder { prev, tail, _phantom } = self;
         MultipleBuilder {
             prev,
-            tail: PairHandler(tail, additional_handler),
+            tail: PairHandler(tail, additional_handler(EmptyHandlerBuilder::new())),
             _phantom,
         }
     }

--- a/mpdelta_gui/src/view.rs
+++ b/mpdelta_gui/src/view.rs
@@ -13,7 +13,10 @@ use mpdelta_core::component::parameter::ParameterValueType;
 use std::sync::Arc;
 
 pub trait Gui<T> {
-    fn ui(&mut self, ctx: &Context, image: &mut impl ImageRegister<T>);
+    fn ui(&mut self, ctx: &Context, image: &mut impl ImageRegister<T>)
+    where
+        Self: Sized;
+    fn ui_dyn(&mut self, ctx: &Context, image: &mut dyn ImageRegister<T>);
 }
 
 pub struct MPDeltaGUI<K: 'static, T, VM, PreviewViewModel, TimelineViewModel, PropertyWindowViewModel> {
@@ -87,6 +90,7 @@ where
                         }
                     });
                     if ui.button("+").clicked() {
+                        println!("new_project1");
                         self.view_model.new_project();
                     }
                 });
@@ -127,5 +131,9 @@ where
                 self.preview.ui(ui, image);
             });
         });
+    }
+
+    fn ui_dyn(&mut self, ctx: &Context, mut image: &mut dyn ImageRegister<T::Image>) {
+        self.ui(ctx, &mut image);
     }
 }

--- a/mpdelta_gui_hot_reload/Cargo.toml
+++ b/mpdelta_gui_hot_reload/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "mpdelta_gui_hot_reload"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = { workspace = true }
+egui = { workspace = true }
+hot-lib-reloader = { workspace = true }
+mpdelta_async_runtime = { workspace = true, features = ["tokio"] }
+mpdelta_components = { workspace = true }
+mpdelta_core = { workspace = true }
+mpdelta_core_vulkano = { workspace = true }
+mpdelta_dyn_usecase = { workspace = true }
+mpdelta_gui = { workspace = true }
+mpdelta_gui_hot_reload_lib = { path = "./mpdelta_gui_hot_reload_lib" }
+mpdelta_gui_vulkano = { workspace = true }
+mpdelta_renderer = { workspace = true }
+mpdelta_services = { workspace = true }
+mpdelta_video_renderer_vulkano = { workspace = true }
+notify = { workspace = true }
+qcell = { workspace = true }
+tokio = { workspace = true }
+vulkano = { workspace = true }
+vulkano-util = { workspace = true }
+vulkano-win = { workspace = true }
+winit = { workspace = true }

--- a/mpdelta_gui_hot_reload/mpdelta_gui_hot_reload_lib/Cargo.toml
+++ b/mpdelta_gui_hot_reload/mpdelta_gui_hot_reload_lib/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
-name = "mpdelta_gui"
+name = "mpdelta_gui_hot_reload_lib"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["rlib", "dylib"]
+
 [dependencies]
-arc-swap = { workspace = true }
-bitflags = { workspace = true }
-cgmath = { workspace = true }
-dashmap = { workspace = true }
+async-trait = { workspace = true }
 egui = { workspace = true }
-futures = { workspace = true }
 mpdelta_async_runtime = { workspace = true }
 mpdelta_core = { workspace = true }
-once_cell = { workspace = true }
+mpdelta_core_vulkano = { workspace = true }
+mpdelta_dyn_usecase = { workspace = true }
+mpdelta_gui = { workspace = true }
+mpdelta_renderer = { workspace = true }
 qcell = { workspace = true }
-regex = { workspace = true }
 tokio = { workspace = true }

--- a/mpdelta_gui_hot_reload/mpdelta_gui_hot_reload_lib/src/lib.rs
+++ b/mpdelta_gui_hot_reload/mpdelta_gui_hot_reload_lib/src/lib.rs
@@ -1,0 +1,105 @@
+use async_trait::async_trait;
+use mpdelta_async_runtime::AsyncRuntimeDyn;
+use mpdelta_core::component::class::ComponentClass;
+use mpdelta_core::component::parameter::{AudioRequiredParamsFrameVariable, ParameterValueType};
+use mpdelta_core::core::ComponentClassLoader;
+use mpdelta_core::ptr::{StaticPointer, StaticPointerOwned};
+use mpdelta_core_vulkano::ImageType;
+use mpdelta_dyn_usecase::{
+    EditUsecaseDyn, GetAvailableComponentClassesUsecaseDyn, GetLoadedProjectsUsecaseDyn, GetRootComponentClassesUsecaseDyn, LoadProjectUsecaseDyn, NewProjectUsecaseDyn, NewRootComponentClassUsecaseDyn, RealtimeRenderComponentUsecaseDyn, RedoUsecaseDyn, SetOwnerForRootComponentClassUsecaseDyn,
+    SubscribeEditEventUsecaseDyn, UndoUsecaseDyn, WriteProjectUsecaseDyn,
+};
+use mpdelta_gui::view::{Gui, MPDeltaGUI};
+use mpdelta_gui::viewmodel::ViewModelParamsImpl;
+use mpdelta_renderer::{Combiner, CombinerBuilder};
+use std::borrow::Cow;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub struct ProjectKey;
+
+pub struct ValueType;
+
+impl ParameterValueType for ValueType {
+    type Image = ImageType;
+    type Audio = ();
+    type Video = ();
+    type File = ();
+    type String = ();
+    type Select = ();
+    type Boolean = ();
+    type Radio = ();
+    type Integer = ();
+    type RealNumber = ();
+    type Vec2 = ();
+    type Vec3 = ();
+    type Dictionary = ();
+    type ComponentClass = ();
+}
+
+pub struct TmpAudioCombiner;
+
+impl CombinerBuilder<()> for TmpAudioCombiner {
+    type Request = ();
+    type Param = AudioRequiredParamsFrameVariable;
+    type Combiner = TmpAudioCombiner;
+
+    fn new_combiner(&self, _request: Self::Request) -> Self::Combiner {
+        TmpAudioCombiner
+    }
+}
+
+impl Combiner<()> for TmpAudioCombiner {
+    type Param = AudioRequiredParamsFrameVariable;
+
+    fn add(&mut self, _data: (), _param: Self::Param) {}
+
+    fn collect(self) {}
+}
+
+#[derive(Default)]
+pub struct ComponentClassList(Vec<StaticPointerOwned<RwLock<dyn ComponentClass<ProjectKey, ValueType>>>>, Vec<StaticPointer<RwLock<dyn ComponentClass<ProjectKey, ValueType>>>>);
+
+impl ComponentClassList {
+    pub fn new() -> ComponentClassList {
+        Default::default()
+    }
+
+    pub fn add(&mut self, class: impl ComponentClass<ProjectKey, ValueType> + 'static) -> &mut Self {
+        let class = StaticPointerOwned::new(RwLock::new(class)).map(|arc| arc as _, |weak| weak as _);
+        let reference = StaticPointerOwned::reference(&class).clone();
+        self.0.push(class);
+        self.1.push(reference);
+        self
+    }
+}
+
+#[async_trait]
+impl ComponentClassLoader<ProjectKey, ValueType> for ComponentClassList {
+    async fn get_available_component_classes(&self) -> Cow<[StaticPointer<RwLock<dyn ComponentClass<ProjectKey, ValueType>>>]> {
+        Cow::Borrowed(&self.1)
+    }
+}
+
+pub type Param = ViewModelParamsImpl<
+    ProjectKey,
+    Arc<dyn AsyncRuntimeDyn<()>>,
+    Arc<dyn EditUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn SubscribeEditEventUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn GetAvailableComponentClassesUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn GetLoadedProjectsUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn GetRootComponentClassesUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn LoadProjectUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn NewProjectUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn NewRootComponentClassUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn RealtimeRenderComponentUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn RedoUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn SetOwnerForRootComponentClassUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn UndoUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+    Arc<dyn WriteProjectUsecaseDyn<ProjectKey, ValueType> + Send + Sync>,
+>;
+
+#[no_mangle]
+pub fn create_gui(params: Param) -> Box<dyn Gui<<ValueType as ParameterValueType>::Image> + Send + Sync> {
+    Box::new(MPDeltaGUI::new(params))
+}

--- a/mpdelta_gui_hot_reload/src/main.rs
+++ b/mpdelta_gui_hot_reload/src/main.rs
@@ -1,0 +1,201 @@
+use egui::Context;
+use mpdelta_async_runtime::AsyncRuntimeDyn;
+use mpdelta_components::rectangle::RectangleClass;
+use mpdelta_core::component::parameter::ParameterValueType;
+use mpdelta_core::core::MPDeltaCore;
+use mpdelta_dyn_usecase::{
+    EditUsecaseDyn, GetAvailableComponentClassesUsecaseDyn, GetLoadedProjectsUsecaseDyn, GetRootComponentClassesUsecaseDyn, LoadProjectUsecaseDyn, NewProjectUsecaseDyn, NewRootComponentClassUsecaseDyn, RealtimeRenderComponentUsecaseDyn, RedoUsecaseDyn, SetOwnerForRootComponentClassUsecaseDyn,
+    SubscribeEditEventUsecaseDyn, UndoUsecaseDyn, WriteProjectUsecaseDyn,
+};
+use mpdelta_gui::view::Gui;
+use mpdelta_gui::viewmodel::ViewModelParamsImpl;
+use mpdelta_gui::ImageRegister;
+use mpdelta_gui_hot_reload_lib::{ComponentClassList, ProjectKey, TmpAudioCombiner, ValueType};
+use mpdelta_gui_vulkano::MPDeltaGUIVulkano;
+use mpdelta_renderer::MPDeltaRendererBuilder;
+use mpdelta_services::history::InMemoryEditHistoryStore;
+use mpdelta_services::id_generator::UniqueIdGenerator;
+use mpdelta_services::project_editor::ProjectEditor;
+use mpdelta_services::project_io::{TemporaryProjectLoader, TemporaryProjectWriter};
+use mpdelta_services::project_store::InMemoryProjectStore;
+use mpdelta_video_renderer_vulkano::ImageCombinerBuilder;
+use notify::{RecursiveMode, Watcher};
+use qcell::TCellOwner;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::atomic::AtomicBool;
+use std::sync::{atomic, Arc, Mutex, MutexGuard, PoisonError};
+use std::time::Duration;
+use std::{process, thread};
+use tokio::runtime::Runtime;
+use tokio::sync::RwLock;
+use vulkano::command_buffer::allocator::{StandardCommandBufferAllocator, StandardCommandBufferAllocatorCreateInfo};
+use vulkano::instance::InstanceCreateInfo;
+use vulkano::Version;
+use vulkano_util::context::{VulkanoConfig, VulkanoContext};
+use vulkano_util::window::VulkanoWindows;
+use winit::event_loop::EventLoop;
+
+#[hot_lib_reloader::hot_module(
+dylib = "mpdelta_gui_hot_reload_lib",
+lib_dir = if cfg ! (debug_assertions) { "target/debug" } else { "target/release" }
+)]
+mod lib {
+    use super::*;
+    use mpdelta_gui::view::Gui;
+    use mpdelta_gui_hot_reload_lib::Param;
+
+    hot_functions_from_file!("mpdelta_gui_hot_reload/mpdelta_gui_hot_reload_lib/src/lib.rs");
+
+    #[lib_change_subscription]
+    pub fn subscribe() -> hot_lib_reloader::LibReloadObserver {}
+}
+
+#[derive(Clone)]
+struct SharedDynGui(Arc<Mutex<Option<Box<dyn Gui<<ValueType as ParameterValueType>::Image> + Send + Sync>>>>);
+
+struct SharedDynGuiSlot<'a>(MutexGuard<'a, Option<Box<dyn Gui<<ValueType as ParameterValueType>::Image> + Send + Sync>>>);
+
+impl Gui<<ValueType as ParameterValueType>::Image> for SharedDynGui {
+    fn ui(&mut self, ctx: &Context, image: &mut impl ImageRegister<<ValueType as ParameterValueType>::Image>)
+    where
+        Self: Sized,
+    {
+        if let Some(gui) = self.0.lock().unwrap_or_else(PoisonError::into_inner).as_mut() {
+            gui.ui_dyn(ctx, image)
+        }
+    }
+
+    fn ui_dyn(&mut self, ctx: &Context, image: &mut dyn ImageRegister<<ValueType as ParameterValueType>::Image>) {
+        if let Some(gui) = self.0.lock().unwrap_or_else(PoisonError::into_inner).as_mut() {
+            gui.ui_dyn(ctx, image)
+        }
+    }
+}
+
+impl SharedDynGui {
+    fn new(gui: Box<dyn Gui<<ValueType as ParameterValueType>::Image> + Send + Sync>) -> SharedDynGui {
+        SharedDynGui(Arc::new(Mutex::new(Some(gui))))
+    }
+
+    fn unload(&self) -> SharedDynGuiSlot {
+        let mut guard = self.0.lock().unwrap_or_else(PoisonError::into_inner);
+        *guard = None;
+        SharedDynGuiSlot(guard)
+    }
+}
+
+impl<'a> SharedDynGuiSlot<'a> {
+    fn load(mut self, gui: Box<dyn Gui<<ValueType as ParameterValueType>::Image> + Send + Sync>) {
+        *self.0 = Some(gui);
+    }
+}
+
+fn main() {
+    dbg!(env!("CARGO"));
+    let context = Arc::new(VulkanoContext::new(VulkanoConfig {
+        instance_create_info: InstanceCreateInfo {
+            max_api_version: Some(Version::V1_2),
+            ..InstanceCreateInfo::default()
+        },
+        ..VulkanoConfig::default()
+    }));
+    let event_loop = EventLoop::new();
+    let windows = VulkanoWindows::default();
+    let runtime = Runtime::new().unwrap();
+    let id_generator = Arc::new(UniqueIdGenerator::new());
+    let project_loader = Arc::new(TemporaryProjectLoader);
+    let project_writer = Arc::new(TemporaryProjectWriter);
+    let project_memory = Arc::new(InMemoryProjectStore::<ProjectKey, ValueType>::new());
+    let mut component_class_loader = ComponentClassList::new();
+    let command_buffer_allocator = StandardCommandBufferAllocator::new(Arc::clone(context.device()), StandardCommandBufferAllocatorCreateInfo::default());
+    component_class_loader.add(RectangleClass::new(Arc::clone(context.graphics_queue()), context.memory_allocator(), &command_buffer_allocator));
+    let component_class_loader = Arc::new(component_class_loader);
+    let key = Arc::new(RwLock::new(TCellOwner::<ProjectKey>::new()));
+    let component_renderer_builder = Arc::new(MPDeltaRendererBuilder::new(Arc::clone(&id_generator), Arc::new(ImageCombinerBuilder::new(Arc::clone(&context))), Arc::new(TmpAudioCombiner), Arc::clone(&key)));
+    let project_editor = Arc::new(ProjectEditor::new(Arc::clone(&key)));
+    let edit_history = Arc::new(InMemoryEditHistoryStore::new(100));
+    let core = Arc::new(MPDeltaCore::new(
+        id_generator,
+        project_loader,
+        project_writer,
+        Arc::clone(&project_memory),
+        project_memory,
+        component_class_loader,
+        component_renderer_builder,
+        project_editor,
+        edit_history,
+        Arc::clone(&key),
+    ));
+    let params = ViewModelParamsImpl::new(
+        Arc::new(runtime.handle().clone()) as Arc<dyn AsyncRuntimeDyn<()>>,
+        Arc::new(Arc::clone(&core) as Arc<dyn EditUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn SubscribeEditEventUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn GetAvailableComponentClassesUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn GetLoadedProjectsUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn GetRootComponentClassesUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn LoadProjectUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn NewProjectUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn NewRootComponentClassUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn RealtimeRenderComponentUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn RedoUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn SetOwnerForRootComponentClassUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn UndoUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::new(Arc::clone(&core) as Arc<dyn WriteProjectUsecaseDyn<ProjectKey, ValueType> + Send + Sync>),
+        Arc::clone(&key),
+    );
+    let gui = lib::create_gui(params.clone());
+    let gui = SharedDynGui::new(gui);
+    let stop_signal = Arc::new(AtomicBool::new(false));
+    let reload_thread = thread::spawn({
+        let gui = gui.clone();
+        let stop_signal = Arc::clone(&stop_signal);
+        move || loop {
+            let Some(guard) = lib::subscribe().wait_for_about_to_reload_timeout(Duration::from_millis(500)) else {
+                if stop_signal.load(atomic::Ordering::Acquire) {
+                    break;
+                }
+                continue;
+            };
+            let slot = gui.unload();
+            drop(guard);
+            lib::subscribe().wait_for_reload();
+            slot.load(lib::create_gui(params.clone()));
+        }
+    });
+    let mut process = None::<process::Child>;
+    let mut watcher = notify::recommended_watcher(move |res| match res {
+        Ok(event) => {
+            println!("event: {:?}", event);
+            let result = process::Command::new(env!("CARGO"))
+                .arg("build")
+                .args(["--package", "mpdelta_gui_hot_reload_lib"])
+                .args::<&[&str], _>(if cfg!(debug_assertions) { &[] } else { &["--release"] })
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .spawn();
+            let child_process = match result {
+                Ok(child_process) => child_process,
+                Err(err) => {
+                    println!("failed to spawn child process: {err}");
+                    return;
+                }
+            };
+            if let Some(Err(error)) = process.as_mut().map(process::Child::kill) {
+                println!("{error}");
+            }
+            process = Some(child_process);
+        }
+        Err(e) => println!("watch error: {:?}", e),
+    })
+    .unwrap();
+    let watch_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../mpdelta_gui"));
+    watcher.watch(watch_path, RecursiveMode::Recursive).unwrap();
+    let gui = MPDeltaGUIVulkano::new(context, event_loop, windows, gui);
+    gui.main();
+    stop_signal.store(true, atomic::Ordering::Release);
+    watcher.unwatch(watch_path).unwrap();
+    reload_thread.join().unwrap();
+    drop(core);
+    drop(runtime);
+}

--- a/mpdelta_renderer/Cargo.toml
+++ b/mpdelta_renderer/Cargo.toml
@@ -17,4 +17,4 @@ mpdelta_core = { workspace = true }
 once_cell = { workspace = true }
 qcell = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features=["full"] }

--- a/mpdelta_renderer/src/cell_by_need.rs
+++ b/mpdelta_renderer/src/cell_by_need.rs
@@ -205,7 +205,7 @@ mod tests {
                 counter.fetch_add(1, atomic::Ordering::SeqCst);
                 let lock = Arc::clone(&lock);
                 async move {
-                    lock.lock().await;
+                    let _ = lock.lock().await;
                     arg
                 }
             }

--- a/mpdelta_services/src/project_editor.rs
+++ b/mpdelta_services/src/project_editor.rs
@@ -52,7 +52,7 @@ impl<K, T> Drop for ProjectEditListenerGuard<K, T> {
 }
 
 #[async_trait]
-impl<K, T> Editor<K, T> for ProjectEditor<K, T> {
+impl<K, T: 'static> Editor<K, T> for ProjectEditor<K, T> {
     type Log = ProjectEditLog;
     type Err = ProjectEditError;
     type EditEventListenerGuard = ProjectEditListenerGuard<K, T>;


### PR DESCRIPTION
closes: #7

GUIの開発用に、ホットリロードができるようにした
ついでにAsyncRuntimeを型引数にしてあるが、これは単にhot-lib-reloaderを使うだけだとtokioが2重に使われて変な動作になったから