### PR TITLE
rustfmtのworkflowがすべてのブランチへのpushで実行されるように

### DIFF
--- a/.github/workflows/rustfmt_main.yml
+++ b/.github/workflows/rustfmt_main.yml
@@ -1,9 +1,5 @@
 name: rustfmt on main branch
-on:
-  pull_request:
-    branches:
-      - main
-    types: [closed]
+on: push
 permissions:
   contents: write
 
@@ -11,7 +7,6 @@ jobs:
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ impl ComponentClassLoader<ProjectKey, ValueType> for ComponentClassList {
 }
 
 fn main() {
-    let context=Arc::new(VulkanoContext::new(VulkanoConfig {
+    let context = Arc::new(VulkanoContext::new(VulkanoConfig {
         instance_create_info: InstanceCreateInfo {
             max_api_version: Some(Version::V1_2),
             ..InstanceCreateInfo::default()


### PR DESCRIPTION
merge時にのみrustfmtをするにはmerge queueなるものがあるらしいが、個人のリポジトリでは使えないようなのでこれで妥協