### PR TITLE
ファイルの読み込みにmemmapを利用するようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2315,7 @@ dependencies = [
  "icu_segmenter",
  "image 0.25.1",
  "lyon_tessellation",
+ "memmap2 0.9.4",
  "mpdelta_core",
  "mpdelta_core_audio",
  "mpdelta_core_vulkano",
@@ -3689,7 +3699,7 @@ checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2",
+ "memmap2 0.5.10",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -3882,7 +3892,7 @@ dependencies = [
  "dlib",
  "lazy_static",
  "log",
- "memmap2",
+ "memmap2 0.5.10",
  "nix 0.24.3",
  "pkg-config",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ icu_segmenter = "1.4.0"
 image = { version = "0.25.1", features = ["png"], default-features = false }
 indexmap = "2.2.6"
 lyon_tessellation = { version = "1.0.14", default-features = false }
+memmap2 = "0.9.4"
 moka = { version = "0.12.7", features = ["future"], default-features = false }
 mpdelta_async_runtime = { path = "mpdelta_common/mpdelta_async_runtime" }
 mpdelta_audio_mixer = { path = "mpdelta_audio_mixer" }

--- a/mpdelta_components/Cargo.toml
+++ b/mpdelta_components/Cargo.toml
@@ -16,6 +16,7 @@ icu_properties = { workspace = true }
 icu_segmenter = { workspace = true }
 image = { workspace = true }
 lyon_tessellation = { workspace = true }
+memmap2 = { workspace = true }
 mpdelta_core = { workspace = true }
 mpdelta_core_audio = { workspace = true }
 mpdelta_core_vulkano = { workspace = true }


### PR DESCRIPTION
現状は[`<File as std::os::windows::fs::FileExt>::seek_read`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html#tymethod.seek_read)などを利用しており、これは並列実行時の性能が良くないことがわかっている
memmapを使って読みこむようにすることでこれを解決する