### PR TITLE
mainブランチでもCIを動かすように

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,5 +1,9 @@
-name: clippy lint in pull request
-on: pull_request
+name: clippy lint
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   rustfmt:

--- a/.github/workflows/rustfmt_check.yml
+++ b/.github/workflows/rustfmt_check.yml
@@ -1,5 +1,9 @@
-name: rustfmt check in pull request
-on: pull_request
+name: rustfmt check
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   rustfmt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
-name: test in pull request
-on: pull_request
+name: cargo test
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   rustfmt:


### PR DESCRIPTION
on: pull_requestだけだとキャッシュの再利用が効かないため