### PR TITLE
fix text rendering

### DIFF
--- a/mpdelta_components/src/text_renderer.rs
+++ b/mpdelta_components/src/text_renderer.rs
@@ -783,6 +783,7 @@ async fn parse(text: &str) -> (ShapingBuilder<TextData>, Vec<(Arc<Vec<u8>>, u32)
                         return;
                     }
                     (Some(_), None) => {
+                        iter.next();
                         return;
                     }
                     (Some(_), Some(_)) => return,


### PR DESCRIPTION
空閉じタグ`</>`が描画結果に残っていた