### PR TITLE
clippyで--testsオプションを使う

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -35,4 +35,4 @@ jobs:
             target/
             target_for_shaders/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo +stable clippy --workspace --locked -- -D warnings
+      - run: cargo +stable clippy --workspace --tests --locked -- -D warnings


### PR DESCRIPTION
今まではテストコード(`#[cfg(test)]`内)がclippyの対象外になっていたらしい