### PR TITLE
音声まわりの処理に形式的なテストを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "mpdelta_renderer",
  "smallvec",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,6 +3301,7 @@ name = "mpdelta_dsp"
 version = "0.1.0"
 dependencies = [
  "num",
+ "proptest",
  "thiserror 2.0.0",
 ]
 

--- a/mpdelta_audio_mixer/Cargo.toml
+++ b/mpdelta_audio_mixer/Cargo.toml
@@ -13,4 +13,6 @@ smallvec = { workspace = true }
 
 [dev-dependencies]
 mpdelta_core_test_util = { workspace = true }
+mpdelta_dsp = { workspace = true, features = ["formal_test"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
+uuid = { workspace = true }

--- a/mpdelta_audio_mixer/src/lib.rs
+++ b/mpdelta_audio_mixer/src/lib.rs
@@ -2,11 +2,12 @@ use mpdelta_core::common::mixed_fraction::MixedFraction;
 use mpdelta_core::time::TimelineTime;
 use mpdelta_core_audio::multi_channel_audio::{MultiChannelAudio, MultiChannelAudioMutOp, MultiChannelAudioOp, MultiChannelAudioSliceMut};
 use mpdelta_core_audio::{AudioProvider, AudioType};
-use mpdelta_dsp::Resample;
+use mpdelta_dsp::{Resample, WindowFunction};
 use mpdelta_renderer::{AudioCombinerParam, AudioCombinerRequest, Combiner, CombinerBuilder, GlobalTime, LocalTime, TimeStretch};
 use smallvec::{smallvec, SmallVec};
 use std::cmp::Ordering;
 use std::future::Future;
+use std::ops::{Add, Mul};
 use std::sync::Arc;
 use std::{future, iter};
 
@@ -77,14 +78,14 @@ impl Combiner<AudioType> for MPDeltaAudioMixer {
 struct MixedAudio {
     length: TimelineTime,
     sample_rate: u32,
-    inner: Arc<MixedAudioInner>,
+    inner: Arc<MixedAudioInner<f32, AudioType>>,
 }
 
 #[derive(Clone)]
-struct MixedAudioInner {
-    source: Vec<(AudioType, Arc<TimeStretch<GlobalTime, LocalTime>>)>,
-    buffer: MultiChannelAudio<f32>,
-    single_audio_buffer: MultiChannelAudio<f32>,
+struct MixedAudioInner<T, A> {
+    source: Vec<(A, Arc<TimeStretch<GlobalTime, LocalTime>>)>,
+    buffer: MultiChannelAudio<T>,
+    single_audio_buffer: MultiChannelAudio<T>,
 }
 
 impl AudioProvider for MixedAudio {
@@ -111,9 +112,26 @@ impl AudioProvider for MixedAudio {
     }
 }
 
-fn compute_audio_inner<F>(mixed_audio: &mut MixedAudioInner, sample_rate: u32, begin: TimelineTime, end: TimelineTime, mut dst: MultiChannelAudioSliceMut<f32>, combiner: F)
+trait AnyAudioProvider<T> {
+    fn sample_rate_any(&self) -> u32;
+    fn compute_audio_any(&mut self, begin: TimelineTime, dst: MultiChannelAudioSliceMut<T>) -> usize;
+}
+
+impl AnyAudioProvider<f32> for AudioType {
+    fn sample_rate_any(&self) -> u32 {
+        <AudioType as AudioProvider>::sample_rate(self)
+    }
+
+    fn compute_audio_any(&mut self, begin: TimelineTime, dst: MultiChannelAudioSliceMut<f32>) -> usize {
+        <AudioType as AudioProvider>::compute_audio(self, begin, dst)
+    }
+}
+
+fn compute_audio_inner<T, A, F>(mixed_audio: &mut MixedAudioInner<T, A>, sample_rate: u32, begin: TimelineTime, end: TimelineTime, mut dst: MultiChannelAudioSliceMut<T>, combiner: F)
 where
-    F: Fn(&mut [f32], &[f32]),
+    T: WindowFunction + Clone + Default + Mul<Output = T> + Add<Output = T>,
+    A: AnyAudioProvider<T>,
+    F: Fn(&mut [T], &[T]),
 {
     let begin = TimelineTime::new(begin.value().round_to_denominator(sample_rate));
     let end = TimelineTime::new(end.value().round_to_denominator(sample_rate));
@@ -122,13 +140,13 @@ where
         MixedFraction::new(i, n, sample_rate)
     };
     let MixedAudioInner { source, buffer, single_audio_buffer } = mixed_audio;
-    buffer.resize(dst.len(), 0.);
-    dst.fill(0.);
+    buffer.resize(dst.len(), T::default());
+    dst.fill(T::default());
     for &mut (ref mut audio, ref param) in source.iter_mut() {
         if param.right().time() <= begin || end <= param.left().time() {
             continue;
         }
-        let audio_sample_rate = audio.sample_rate();
+        let audio_sample_rate = audio.sample_rate_any();
         let begin_pos = begin.max(param.left().time());
         let end_pos = end.min(param.right().time());
         for time_map in param.map_range_iter(begin_pos.into()).take_while(|time_map| time_map.start().time() <= end_pos) {
@@ -139,7 +157,7 @@ where
             let audio_compute_end = audio_range.start.max(audio_range.end);
             let (audio_sample_rate_scaled, _) = (MixedFraction::from_integer(audio_sample_rate as i32) * time_map.scale().abs()).deconstruct_with_round(1);
             let audio_sample_rate_scaled = audio_sample_rate_scaled as u32;
-            let Ok(resample) = Resample::builder(audio_sample_rate_scaled, sample_rate).build() else {
+            let Ok(resample) = Resample::builder(audio_sample_rate_scaled, sample_rate).build::<T>() else {
                 continue;
             };
             let mut resample: SmallVec<[_; 6]> = smallvec![resample; buffer.channels()];
@@ -158,9 +176,9 @@ where
                 let (i, n) = (end - request_begin).deconstruct_with_round(audio_sample_rate);
                 i as usize * audio_sample_rate as usize + n as usize + default_buffer_len
             };
-            single_audio_buffer.resize(buffer_len, 0.);
-            single_audio_buffer.fill(0.);
-            let computed_len = audio.compute_audio(TimelineTime::new(request_begin), single_audio_buffer.slice_mut(..).unwrap());
+            single_audio_buffer.resize(buffer_len, T::default());
+            single_audio_buffer.fill(T::default());
+            let computed_len = audio.compute_audio_any(TimelineTime::new(request_begin), single_audio_buffer.slice_mut(..).unwrap());
             let result = single_audio_buffer.slice(..computed_len).unwrap();
             let Some(default_value) = result.get(0) else {
                 continue;
@@ -168,9 +186,9 @@ where
             let leading = result.slice(..default_buffer_len - leading_zeros).unwrap();
             let body = result.slice(default_buffer_len - leading_zeros..).unwrap();
             for (i, resample) in resample.iter_mut().enumerate() {
-                resample.reset_buffer_with_default_buffer(iter::repeat(default_value).take(leading_zeros).chain(leading.iter()).map(|v| v[i]));
-                resample.extend(body.iter().map(|v| v[i]));
-                let last = body.get(body.len() - 1).unwrap()[i];
+                resample.reset_buffer_with_default_buffer(iter::repeat(default_value).take(leading_zeros).chain(leading.iter()).map(|v| v[i].clone()));
+                resample.extend(body.iter().map(|v| v[i].clone()));
+                let last = body.get(body.len() - 1).unwrap()[i].clone();
                 resample.extend(iter::repeat(last).take(default_buffer_len));
             }
             let skip = {
@@ -178,7 +196,7 @@ where
                 i as usize * sample_rate as usize + n as usize
             };
             let mut resample = resample.iter_mut().map(|resample| resample.skip(skip)).collect::<SmallVec<[_; 6]>>();
-            buffer.resize(0, 0.);
+            buffer.resize(0, T::default());
             let len = iter::from_fn(|| {
                 let sample = resample.iter_mut().map(|resample| resample.next()).collect::<Option<SmallVec<[_; 6]>>>()?;
                 buffer.push(&sample);

--- a/mpdelta_common/mpdelta_dsp/Cargo.toml
+++ b/mpdelta_common/mpdelta_dsp/Cargo.toml
@@ -7,3 +7,9 @@ authors = { workspace = true }
 [dependencies]
 num = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+formal_test = []
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/mpdelta_common/mpdelta_dsp/src/lib.rs
+++ b/mpdelta_common/mpdelta_dsp/src/lib.rs
@@ -2,8 +2,12 @@ use num::Integer;
 use std::collections::VecDeque;
 use std::f64::consts::PI;
 use std::iter;
-use std::ops::Add;
+use std::ops::{Add, Mul};
 use thiserror::Error;
+
+pub trait WindowFunction: Sized {
+    fn window(length: usize, target_sum: f64) -> Box<[Self]>;
+}
 
 pub fn window_at(x: f64) -> f64 {
     kaiser(x) * sinc(x)
@@ -39,6 +43,21 @@ fn sinc(x: f64) -> f64 {
     }
 }
 
+impl WindowFunction for f32 {
+    fn window(length: usize, target_sum: f64) -> Box<[Self]> {
+        assert_eq!(length & 1, 1);
+        if length == 1 {
+            return Box::new([target_sum as f32]);
+        }
+        let length_half = length / 2;
+        let filter_half = (0..=length_half).map(|f| f as f64 / length_half as f64).map(window_at).collect::<Vec<_>>();
+        let filter = filter_half.iter().copied().rev().chain(filter_half.iter().copied().skip(1)).collect::<Box<[_]>>();
+        let sum = filter.iter().copied().sum::<f64>();
+        let scaling = target_sum / sum;
+        filter.iter().copied().map(|f| (f * scaling) as f32).collect()
+    }
+}
+
 pub struct ResampleBuilder {
     original_freq: u32,
     target_freq: u32,
@@ -49,7 +68,10 @@ impl ResampleBuilder {
         ResampleBuilder { original_freq, target_freq }
     }
 
-    pub fn build(self) -> Result<Resample, ResampleConstructError> {
+    pub fn build<T>(self) -> Result<Resample<T>, ResampleConstructError>
+    where
+        T: WindowFunction + Clone + Default + Mul<Output = T> + Add<Output = T>,
+    {
         Resample::from_builder(self)
     }
 }
@@ -61,9 +83,9 @@ pub enum ResampleConstructError {
 }
 
 #[derive(Debug, Clone)]
-pub struct Resample {
-    filter: Box<[(Box<[f32]>, usize)]>,
-    buffer: VecDeque<f32>,
+pub struct Resample<T = f32> {
+    filter: Box<[(Box<[T]>, usize)]>,
+    buffer: VecDeque<T>,
     default_buffer_length: usize,
     filter_index: usize,
     default_filter_index: usize,
@@ -73,8 +95,13 @@ impl Resample {
     pub fn builder(original_freq: u32, target_freq: u32) -> ResampleBuilder {
         ResampleBuilder { original_freq, target_freq }
     }
+}
 
-    fn from_builder(builder: ResampleBuilder) -> Result<Resample, ResampleConstructError> {
+impl<T> Resample<T>
+where
+    T: WindowFunction + Clone + Default + Mul<Output = T> + Add<Output = T>,
+{
+    fn from_builder(builder: ResampleBuilder) -> Result<Resample<T>, ResampleConstructError> {
         let ResampleBuilder { original_freq, target_freq } = builder;
         if original_freq == 0 || target_freq == 0 {
             return Err(ResampleConstructError::InvalidFrequency);
@@ -84,8 +111,10 @@ impl Resample {
         let target = (target_freq / gcd) as usize;
         let pqmax = original.max(target);
         if pqmax == 1 {
+            let filter = T::window(1, 1.);
+            assert_eq!(filter.len(), 1);
             return Ok(Resample {
-                filter: Box::new([(Box::new([1.]), 1)]),
+                filter: Box::new([(filter, 1)]),
                 buffer: VecDeque::new(),
                 default_buffer_length: 0,
                 filter_index: 0,
@@ -93,23 +122,17 @@ impl Resample {
             });
         }
         const N: usize = 10;
-        let filter = {
-            let filter_half = (0..=pqmax * N).map(|f| f as f64 / (pqmax * N) as f64).map(window_at).collect::<Vec<_>>();
-            let filter = filter_half.iter().copied().rev().chain(filter_half.iter().copied().skip(1)).collect::<Box<[_]>>();
-            let sum = filter.iter().copied().sum::<f64>();
-            let scaling = target as f64 / sum;
-            filter.iter().copied().map(|f| (f * scaling) as f32).collect::<Box<[_]>>()
-        };
-        assert_eq!(filter.len() & 1, 1);
-        // println!("{:?}", filter);
+        let filter = T::window(pqmax * N * 2 + 1, target as f64);
+        assert_eq!(filter.len(), pqmax * N * 2 + 1);
+
         let default_buffer_length = filter.len() / 2 / target;
-        let buffer = vec![0.; default_buffer_length].into();
+        let buffer = vec![T::default(); default_buffer_length].into();
 
         let filter = (0..target)
             .map(|n| {
                 let filter_offset = (target - n) * original % target;
                 let step = ((n + 1) * original + target - 1) / target - (n * original + target - 1) / target;
-                let filter = iter::successors(Some(filter_offset), |n| Some(*n + target)).map_while(|n| filter.get(n)).copied().collect::<Box<[_]>>();
+                let filter = iter::successors(Some(filter_offset), |n| Some(*n + target)).map_while(|n| filter.get(n)).cloned().collect::<Box<[_]>>();
                 (filter, step)
             })
             .collect::<Box<[_]>>();
@@ -130,32 +153,32 @@ impl Resample {
         self.default_buffer_length
     }
 
-    pub fn reset_buffer_with_default_buffer(&mut self, default_buffer: impl IntoIterator<Item = f32>) {
+    pub fn reset_buffer_with_default_buffer(&mut self, default_buffer: impl IntoIterator<Item = T>) {
         self.buffer.clear();
         self.buffer.extend(default_buffer.into_iter().take(self.default_buffer_length));
-        iter::repeat(0.).take(self.default_buffer_length - self.buffer.len()).for_each(|v| self.buffer.push_front(v));
+        iter::repeat(T::default()).take(self.default_buffer_length - self.buffer.len()).for_each(|v| self.buffer.push_front(v));
         self.filter_index = self.default_filter_index;
     }
 
     pub fn reset_buffer(&mut self) {
         self.buffer.clear();
-        self.buffer.resize(self.default_buffer_length, 0.);
+        self.buffer.resize(self.default_buffer_length, T::default());
         self.filter_index = self.default_filter_index;
     }
 
     pub fn fill_tail_by_zero(&mut self) {
-        self.buffer.extend(iter::repeat(0.).take(self.default_buffer_length));
+        self.buffer.extend(iter::repeat(T::default()).take(self.default_buffer_length));
     }
 
     pub fn buffer_len(&self) -> usize {
         self.buffer.len()
     }
 
-    pub fn extend(&mut self, items: impl IntoIterator<Item = f32>) {
+    pub fn extend(&mut self, items: impl IntoIterator<Item = T>) {
         self.buffer.extend(items)
     }
 
-    pub fn take_result(&mut self) -> Box<[f32]> {
+    pub fn take_result(&mut self) -> Box<[T]> {
         let mut result = Vec::new();
         let iter = self.filter[self.filter_index..].iter().chain(self.filter.iter().cycle()).scan(0, |sum, (filter, offset)| {
             let current_sum = *sum;
@@ -164,7 +187,7 @@ impl Resample {
         });
         for (i, (filter, offset)) in iter.enumerate() {
             if offset + filter.len() < self.buffer.len() {
-                let value = self.buffer.range(offset..).copied().zip(filter.iter().copied()).map(|(v, f)| v * f).sum::<f32>();
+                let value = self.buffer.range(offset..).cloned().zip(filter.iter().cloned()).map(|(v, f)| v * f).reduce(Add::add).unwrap_or_else(T::default);
                 result.push(value);
             } else {
                 self.buffer.drain(..offset);
@@ -176,17 +199,30 @@ impl Resample {
     }
 }
 
-impl Iterator for Resample {
-    type Item = f32;
+impl<T> Iterator for Resample<T>
+where
+    T: Clone + Default + Mul<Output = T> + Add<Output = T>,
+{
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         let (filter, offset) = &self.filter[self.filter_index];
         if self.buffer.len() < filter.len() {
             return None;
         }
-        let value = self.buffer.iter().copied().zip(filter.iter().copied()).map(|(v, f)| v * f).reduce(Add::add).unwrap_or(0.);
+        let value = self.buffer.iter().cloned().zip(filter.iter().cloned()).map(|(v, f)| v * f).reduce(Add::add).unwrap_or_else(T::default);
         self.buffer.drain(..offset);
         self.filter_index = (self.filter_index + 1) % self.filter.len();
         Some(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_window_f32() {
+        assert_eq!(*f32::window(1, 1.), [1.]);
     }
 }

--- a/mpdelta_common/mpdelta_dsp/src/lib.rs
+++ b/mpdelta_common/mpdelta_dsp/src/lib.rs
@@ -125,8 +125,10 @@ where
             });
         }
         const N: usize = 10;
-        let filter = T::window(pqmax * N * 2 + 1, target as f64);
-        assert_eq!(filter.len(), pqmax * N * 2 + 1);
+        let window_len_half = pqmax * N;
+        let window_len = window_len_half * 2 + 1;
+        let filter = T::window(window_len, target as f64);
+        assert_eq!(filter.len(), window_len);
 
         let default_buffer_length = filter.len() / 2 / target;
         let buffer = vec![T::default(); default_buffer_length].into();
@@ -139,8 +141,8 @@ where
                 (filter, step)
             })
             .collect::<Box<[_]>>();
-        // println!("{:?}", filter.iter().map(|(_, step)| *step).collect::<Vec<_>>());
-        let start_offset = filter.len() / 2 % target;
+
+        let start_offset = window_len_half % target;
         let (filter_index, _) = (0..target).map(|n| (target - n) * original % target).enumerate().find(|(_, offset)| *offset == start_offset).unwrap();
 
         Ok(Resample {
@@ -160,7 +162,7 @@ where
         self.buffer.clear();
         self.buffer.extend(default_buffer.into_iter().take(self.default_buffer_length));
         iter::repeat(T::default()).take(self.default_buffer_length - self.buffer.len()).for_each(|v| self.buffer.push_front(v));
-        self.filter_index = self.default_filter_index;
+        self.filter_index = 0;
     }
 
     pub fn reset_buffer(&mut self) {

--- a/mpdelta_common/mpdelta_dsp/src/test_util.rs
+++ b/mpdelta_common/mpdelta_dsp/src/test_util.rs
@@ -1,0 +1,116 @@
+use crate::WindowFunction;
+use std::ops::{Add, Mul};
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum FormalExpression {
+    #[default]
+    Zero,
+    Sum(Vec<FormalExpression>),
+    Product(Vec<FormalExpression>),
+    Value(usize),
+    Window(usize),
+}
+
+impl FormalExpression {
+    pub fn value(value: usize) -> Self {
+        FormalExpression::Value(value)
+    }
+}
+
+impl WindowFunction for FormalExpression {
+    fn window(length: usize, _target_sum: f64) -> Box<[Self]> {
+        (0..length).map(FormalExpression::Window).collect()
+    }
+}
+
+impl Add for FormalExpression {
+    type Output = FormalExpression;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (FormalExpression::Zero, x) | (x, FormalExpression::Zero) => x,
+            (FormalExpression::Sum(mut x), FormalExpression::Sum(y)) => {
+                x.extend(y);
+                FormalExpression::Sum(x)
+            }
+            (FormalExpression::Sum(mut x), y) => {
+                x.push(y);
+                FormalExpression::Sum(x)
+            }
+            (x, FormalExpression::Sum(mut y)) => {
+                y.insert(0, x);
+                FormalExpression::Sum(y)
+            }
+            (x, y) => FormalExpression::Sum(vec![x, y]),
+        }
+    }
+}
+
+impl Mul for FormalExpression {
+    type Output = FormalExpression;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (FormalExpression::Zero, _) | (_, FormalExpression::Zero) => FormalExpression::Zero,
+            (FormalExpression::Product(mut x), FormalExpression::Product(y)) => {
+                x.extend(y);
+                FormalExpression::Product(x)
+            }
+            (FormalExpression::Product(mut x), y) => {
+                x.push(y);
+                FormalExpression::Product(x)
+            }
+            (x, FormalExpression::Product(mut y)) => {
+                y.insert(0, x);
+                FormalExpression::Product(y)
+            }
+            (x, y) => FormalExpression::Product(vec![x, y]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_window_formal_expression() {
+        assert_eq!(*FormalExpression::window(5, 1.), [FormalExpression::Window(0), FormalExpression::Window(1), FormalExpression::Window(2), FormalExpression::Window(3), FormalExpression::Window(4)]);
+    }
+
+    #[test]
+    fn test_add_formal_expression() {
+        assert_eq!(FormalExpression::Value(1) + FormalExpression::Zero, FormalExpression::Value(1));
+        assert_eq!(FormalExpression::Value(1) + FormalExpression::Value(2), FormalExpression::Sum(vec![FormalExpression::Value(1), FormalExpression::Value(2)]));
+        assert_eq!(
+            FormalExpression::Value(1) + FormalExpression::Sum(vec![FormalExpression::Value(2), FormalExpression::Value(3)]),
+            FormalExpression::Sum(vec![FormalExpression::Value(1), FormalExpression::Value(2), FormalExpression::Value(3)])
+        );
+        assert_eq!(
+            FormalExpression::Sum(vec![FormalExpression::Value(1), FormalExpression::Value(2)]) + FormalExpression::Value(3),
+            FormalExpression::Sum(vec![FormalExpression::Value(1), FormalExpression::Value(2), FormalExpression::Value(3)])
+        );
+        assert_eq!(
+            FormalExpression::Sum(vec![FormalExpression::Value(1), FormalExpression::Value(2)]) + FormalExpression::Sum(vec![FormalExpression::Value(3), FormalExpression::Value(4)]),
+            FormalExpression::Sum(vec![FormalExpression::Value(1), FormalExpression::Value(2), FormalExpression::Value(3), FormalExpression::Value(4)])
+        );
+    }
+
+    #[test]
+    fn test_mul_formal_expression() {
+        assert_eq!(FormalExpression::Value(1) * FormalExpression::Zero, FormalExpression::Zero);
+        assert_eq!(FormalExpression::Value(1) * FormalExpression::Value(2), FormalExpression::Product(vec![FormalExpression::Value(1), FormalExpression::Value(2)]));
+        assert_eq!(
+            FormalExpression::Value(1) * FormalExpression::Product(vec![FormalExpression::Value(2), FormalExpression::Value(3)]),
+            FormalExpression::Product(vec![FormalExpression::Value(1), FormalExpression::Value(2), FormalExpression::Value(3)])
+        );
+        assert_eq!(
+            FormalExpression::Product(vec![FormalExpression::Value(1), FormalExpression::Value(2)]) * FormalExpression::Value(3),
+            FormalExpression::Product(vec![FormalExpression::Value(1), FormalExpression::Value(2), FormalExpression::Value(3)])
+        );
+        assert_eq!(
+            FormalExpression::Product(vec![FormalExpression::Value(1), FormalExpression::Value(2)]) * FormalExpression::Product(vec![FormalExpression::Value(3), FormalExpression::Value(4)]),
+            FormalExpression::Product(vec![FormalExpression::Value(1), FormalExpression::Value(2), FormalExpression::Value(3), FormalExpression::Value(4)])
+        );
+    }
+}


### PR DESCRIPTION
今まではf32のみのサポートだったのでなんとなくのテストしかできていなかったが、サンプルレベルで計算木を構築すればちゃんとテストできるので、やる