### PR TITLE
rustdocをPRに対するCIでも実行するように

### DIFF
--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -1,5 +1,6 @@
 name: rustdoc pages
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -41,6 +42,7 @@ jobs:
           path: target/doc
 
   deploy:
+    if: github.event_name == 'push'
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
ドキュメント関連しか無くそこまで問題ないとはいえ、mainにマージしないと動作確認ができないのは不便でした