### PR TITLE
actions/cacheでrestore-keyを使うように

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -29,7 +29,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -29,13 +29,13 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}
       - uses: actions/cache@v4
         with:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: | 
-            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-clippy-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-clippy-
       - run: cargo +stable clippy --workspace --tests --locked -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.stable-toolchain.outputs.name }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: | 
-            ${{ runner.os }}-cargo-${{ steps.stable-toolchain.outputs.name }}-clippy-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-clippy-
       - run: cargo +stable clippy --workspace --tests --locked -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,14 +15,13 @@ jobs:
           sudo apt update
           sudo apt install yasm libgtk-3-dev libasound2-dev libopenh264-dev -y
       - uses: dtolnay/rust-toolchain@stable
+        id: main_toolchain
         with:
           components: clippy
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
-      - id: rust-stable-version
-        run: echo "version=$(rustc +stable --version)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: |
@@ -36,7 +35,7 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.stable-toolchain.outputs.name }}-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: | 
-            ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-clippy-
+            ${{ runner.os }}-cargo-${{ steps.stable-toolchain.outputs.name }}-clippy-
       - run: cargo +stable clippy --workspace --tests --locked -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
+      - id: rust-stable-version
+        run: echo "version=$(rustc +stable --version)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: |
@@ -34,5 +36,7 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: | 
+            ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-clippy-
       - run: cargo +stable clippy --workspace --tests --locked -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
+      - id: get-month
+        run: |
+          echo "month=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
+        shell: bash
       - uses: actions/cache@v4
         with:
           path: |
@@ -29,7 +33,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}
+          key: ${{ runner.os }}-cargo-${{ steps.get-month.outputs.month }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -29,7 +29,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -29,15 +29,15 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}
       - uses: actions/cache@v4
         with:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-doc-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-doc-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-doc-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-doc-
       - run: RUSTDOCFLAGS="--enable-index-page" cargo +${{ steps.main_toolchain.outputs.name }} doc --locked --workspace --document-private-items --no-deps -Zrustdoc-map
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
-      - id: rust-stable-version
-        run: echo "version=$(rustc +stable --version)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: |
@@ -37,9 +35,9 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-doc-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-doc-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-doc-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-doc-
       - run: RUSTDOCFLAGS="--enable-index-page" cargo +${{ steps.main_toolchain.outputs.name }} doc --locked --workspace --document-private-items --no-deps -Zrustdoc-map
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
+      - id: rust-stable-version
+        run: echo "version=$(rustc +stable --version)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: |
@@ -35,7 +37,9 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-doc-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-doc-
       - run: RUSTDOCFLAGS="--enable-index-page" cargo +${{ steps.main_toolchain.outputs.name }} doc --locked --workspace --document-private-items --no-deps -Zrustdoc-map
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
+      - id: get-month
+        run: |
+          echo "month=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
+        shell: bash
       - uses: actions/cache@v4
         with:
           path: |
@@ -29,7 +33,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}
+          key: ${{ runner.os }}-cargo-${{ steps.get-month.outputs.month }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
+      - id: rust-stable-version
+        run: echo "version=$(rustc +stable --version)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: |
@@ -34,5 +36,7 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-test-
       - run: cargo +stable test --workspace --locked

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,13 @@ jobs:
           sudo apt update
           sudo apt install yasm libgtk-3-dev libasound2-dev libopenh264-dev mesa-vulkan-drivers libvulkan-dev -y
       - uses: dtolnay/rust-toolchain@stable
+        id: main_toolchain
         with:
           components: clippy
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
-      - id: rust-stable-version
-        run: echo "version=$(rustc +stable --version)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: |
@@ -36,7 +35,7 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-stable-version.outputs.version }}-test-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-test-
       - run: cargo +stable test --workspace --locked

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           toolchain: nightly-2023-05-27
           components: "rust-src,rustc-dev,llvm-tools-preview"
+      - id: get-month
+        run: |
+          echo "month=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
+        shell: bash
       - uses: actions/cache@v4
         with:
           path: |
@@ -29,7 +33,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}
+          key: ${{ runner.os }}-cargo-${{ steps.get-month.outputs.month }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,13 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}
       - uses: actions/cache@v4
         with:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.name }}-test-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-test-
       - run: cargo +stable test --workspace --locked


### PR DESCRIPTION
これをやるとキャッシュのサイズが無限に膨らんでいくことを心配していたが、そういえばフルビルドが必須になるイベントが6週間毎にやってくるのでそれに合わせてキャッシュをinvalidateすればよいことに気づいた