### PR TITLE
rustcのバージョンをキャッシュのkeyにするように

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,9 +15,10 @@ jobs:
           sudo apt update
           sudo apt install yasm libgtk-3-dev libasound2-dev libopenh264-dev -y
       - uses: dtolnay/rust-toolchain@stable
-        id: main_toolchain
         with:
           components: clippy
+      - id: main_toolchain_version
+        run: echo "rustc_version=$(rustc --version | sed -e s/\(.*\)//g)" >> $GITHUB_OUTPUT
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-05-27
@@ -39,7 +40,7 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain_version.outputs.rustc_version }}-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: | 
-            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-clippy-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain_version.outputs.rustc_version }}-clippy-
       - run: cargo +stable clippy --workspace --tests --locked -- -D warnings

--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -18,6 +18,8 @@ jobs:
         id: main_toolchain
         with:
           components: clippy
+      - id: main_toolchain_version
+        run: echo "rustc_version=$(rustc --version | sed -e s/\(.*\)//g)" >> $GITHUB_OUTPUT
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-05-27
@@ -39,9 +41,9 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-doc-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain_version.outputs.rustc_version }}-doc-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-doc-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain_version.outputs.rustc_version }}-doc-
       - run: RUSTDOCFLAGS="--enable-index-page" cargo +${{ steps.main_toolchain.outputs.name }} doc --locked --workspace --document-private-items --no-deps -Zrustdoc-map
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,10 @@ jobs:
           sudo apt update
           sudo apt install yasm libgtk-3-dev libasound2-dev libopenh264-dev mesa-vulkan-drivers libvulkan-dev -y
       - uses: dtolnay/rust-toolchain@stable
-        id: main_toolchain
         with:
           components: clippy
+      - id: main_toolchain_version
+        run: echo "rustc_version=$(rustc --version | sed -e s/\(.*\)//g)" >> $GITHUB_OUTPUT
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-05-27
@@ -39,7 +40,7 @@ jobs:
           path: |
             target/
             target_for_shaders/
-          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ steps.main_toolchain_version.outputs.rustc_version }}-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.main_toolchain.outputs.cachekey }}-test-
+            ${{ runner.os }}-cargo-${{ steps.main_toolchain_version.outputs.rustc_version }}-test-
       - run: cargo +stable test --workspace --locked


### PR DESCRIPTION
rust-toolchainのoutputにあるcachekeyを使っていると、docのkeyが毎日変わる
ある程度継続して読み込まれつつも適当なタイミングでリセットがかかるkeyとしてバージョン名だけを使う