### PR TITLE
fix clippy warnings

### DIFF
--- a/mpdelta_components/common/src/color.rs
+++ b/mpdelta_components/common/src/color.rs
@@ -11,25 +11,25 @@ pub fn parse_color(s: &str) -> Option<[u8; 4]> {
             let Ok(c) = u16::from_str_radix(s, 16) else {
                 return None;
             };
-            let c = (c << 4 | 0xf) as u32;
-            let c = (c << 8 | c) & 0x00ff00ff;
-            let c = (c << 4 | c) & 0x0f0f0f0f;
-            Some((c << 4 | c).to_be_bytes())
+            let c = ((c << 4) | 0xf) as u32;
+            let c = ((c << 8) | c) & 0x00ff00ff;
+            let c = ((c << 4) | c) & 0x0f0f0f0f;
+            Some(((c << 4) | c).to_be_bytes())
         }
         4 => {
             let Ok(c) = u16::from_str_radix(s, 16) else {
                 return None;
             };
             let c = c as u32;
-            let c = (c << 8 | c) & 0x00ff00ff;
-            let c = (c << 4 | c) & 0x0f0f0f0f;
-            Some((c << 4 | c).to_be_bytes())
+            let c = ((c << 8) | c) & 0x00ff00ff;
+            let c = ((c << 4) | c) & 0x0f0f0f0f;
+            Some(((c << 4) | c).to_be_bytes())
         }
         6 => {
             let Ok(c) = u32::from_str_radix(s, 16) else {
                 return None;
             };
-            Some((c << 8 | 0xff).to_be_bytes())
+            Some(((c << 8) | 0xff).to_be_bytes())
         }
         8 => {
             let Ok(c) = u32::from_str_radix(s, 16) else {

--- a/mpdelta_components/text_renderer/shader/src/lib.rs
+++ b/mpdelta_components/text_renderer/shader/src/lib.rs
@@ -54,7 +54,12 @@ pub mod shader {
         #[inline(always)]
         fn inner(vertex: FontVertex, glyph_data: &[GlyphStyle], constant: &Constant) -> VSOut {
             let glyph_data = glyph_data[vertex.glyph as usize];
-            let color = Vec4::new((glyph_data.color >> 24 & 0xFF) as f32 / 255., (glyph_data.color >> 16 & 0xFF) as f32 / 255., (glyph_data.color >> 8 & 0xFF) as f32 / 255., (glyph_data.color & 0xFF) as f32 / 255.);
+            let color = Vec4::new(
+                ((glyph_data.color >> 24) & 0xFF) as f32 / 255.,
+                ((glyph_data.color >> 16) & 0xFF) as f32 / 255.,
+                ((glyph_data.color >> 8) & 0xFF) as f32 / 255.,
+                (glyph_data.color & 0xFF) as f32 / 255.,
+            );
             VSOut {
                 position: constant.transform * vec4(vertex.x * glyph_data.scale + glyph_data.offset_x, -vertex.y * glyph_data.scale + glyph_data.offset_y, 0., 1.),
                 color,

--- a/mpdelta_core/src/common/mixed_fraction.rs
+++ b/mpdelta_core/src/common/mixed_fraction.rs
@@ -120,7 +120,7 @@ impl MixedFraction {
     pub const MAX: MixedFraction = MixedFraction::new_inner(INTEGER_MAX, FRAC_VALUE_MASK - 1, FRAC_VALUE_MASK);
 
     const fn new_inner(integer: i32, numerator: u32, denominator: u32) -> MixedFraction {
-        MixedFraction((integer as i64) << 36 | (numerator as i64) << 18 | (denominator as i64))
+        MixedFraction(((integer as i64) << 36) | ((numerator as i64) << 18) | (denominator as i64))
     }
 
     /// Create new MixedFraction(I + N / D) from I, N, and D

--- a/mpdelta_core/src/component/processor.rs
+++ b/mpdelta_core/src/component/processor.rs
@@ -43,7 +43,7 @@ where
     fn right(&self) -> &MarkerPin;
 }
 
-impl<'a, T, C> ComponentsLinksPair<T> for &'a C
+impl<T, C> ComponentsLinksPair<T> for &C
 where
     T: ParameterValueType,
     C: ComponentsLinksPair<T>,
@@ -87,7 +87,7 @@ where
     }
 }
 
-impl<'a, T> ComponentsLinksPair<T> for &'a dyn ComponentsLinksPair<T>
+impl<T> ComponentsLinksPair<T> for &dyn ComponentsLinksPair<T>
 where
     T: ParameterValueType,
 {


### PR DESCRIPTION
1.84(beta-1.85でfixしたので1.85も)で変更されたlintルールへの対応